### PR TITLE
Use ssh-client/ssh-client instead of phpseclib NET/SSH

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         "php": ">=5.3.0",
         "symfony/console": "~2.7",
         "symfony/yaml": "~2.7",
-        "ssh-client/ssh-client": "^0.1.3",
-        "phpseclib/phpseclib": "~2.0"
+        "ssh-client/ssh-client": "^0.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,11 @@
         "php": ">=5.3.0",
         "symfony/console": "~2.7",
         "symfony/yaml": "~2.7",
+        "ssh-client/ssh-client": "^0.1.3",
         "phpseclib/phpseclib": "~2.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.8",
         "linkorb/autotune": "~1.0"
     },
     "autoload": {
@@ -25,6 +27,17 @@
             "Droid\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Droid\\Test\\": "test/Droid/"
+        }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/boite/ssh-client"
+        }
+    ],
     "bin": ["bin/droid"],
     "license": "MIT"
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.0",
         "symfony/console": "~2.7",
         "symfony/yaml": "~2.7",
-        "ssh-client/ssh-client": "^0.1.3"
+        "ssh-client/ssh-client": "^0.1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/example/droid.yml
+++ b/example/droid.yml
@@ -64,3 +64,15 @@ targets:
             - deploy_ssh:
                 hosts: %deploy_hosts%
                 sshkey: %deploy_sshkey%
+
+hosts:
+    myhost:
+        username: myuser
+        keyfile: '~/.ssh/id_rsa'
+    my.sekret.host:
+        username: myuser
+        ssh_gateway: gateway_host
+    gateway_host:
+        username: myuser
+        ssh_options:
+            LogLevel: VERBOSE

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="phpunit.xsd"
+         bootstrap="test/bootstrap.php"
+         backupGlobals="false"
+         verbose="true">
+  <testsuites>
+    <testsuite name="Droid">
+      <directory suffix="Test.php">test/Droid</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,6 +13,8 @@ use RuntimeException;
 
 class Application extends ConsoleApplication
 {
+    const DROID_BIN_NAME = 'droid.phar';
+
     protected $project;
     protected $inventory;
     protected $autoLoader;
@@ -136,7 +138,12 @@ class Application extends ConsoleApplication
         }
         return $filename;
     }
-        
+
+    public function getDroidBinaryFilename()
+    {
+        return self::DROID_BIN_NAME;
+    }
+
     public function setAutoLoader($autoLoader)
     {
         $this->autoLoader = $autoLoader;

--- a/src/Command/TargetRunCommand.php
+++ b/src/Command/TargetRunCommand.php
@@ -8,7 +8,10 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use RuntimeException;
+use Droid\Remote\Enabler;
+use Droid\Remote\Synchroniser;
 use Droid\TaskRunner;
+use Droid\Remote\Droid\Remote;
 
 class TargetRunCommand extends Command
 {
@@ -27,9 +30,9 @@ class TargetRunCommand extends Command
             )
         ;
     }
-    
+
     private $target;
-    
+
     public function setTarget($target)
     {
         $this->target = $target;
@@ -44,13 +47,50 @@ class TargetRunCommand extends Command
                 $target = $this->target;
             }
         }
-        $output->writeln("<info>Droid: Running target `$target`</info>");
+
+        $localDroidBinary = null;
+        try {
+            $localDroidBinary = $this->locateLocalDroidBinary();
+        } catch (RuntimeException $e) {
+            $output->writeln(sprintf(
+                '<comment>Unable to run remote commands: %s</comment>',
+                $e->getMessage()
+            ));
+        }
+
+        $enabler = new Enabler(new Synchroniser($localDroidBinary));
         $project = $this->getApplication()->getProject();
-        
-        $runner = new TaskRunner($this->getApplication(), $output);
+        $runner = new TaskRunner($this->getApplication(), $output, $enabler);
+
+        $output->writeln("<info>Droid: Running target `$target`</info>");
+
         $res = $runner->runTarget($project, $target);
-        
+
         $output->writeln("Result: " . $res);
         $output->writeln('--------------------------------------------');
+    }
+
+    protected function locateLocalDroidBinary()
+    {
+        $candidatePath = getcwd() . DIRECTORY_SEPARATOR
+            . $this->getApplication()->getDroidBinaryFilename()
+        ;
+
+        if (!file_exists($candidatePath)) {
+            throw new RuntimeException(sprintf(
+                'Unable to find the droid binary. Tried: "%s"',
+                $candidatePath
+            ));
+        }
+        $fh = fopen($candidatePath, 'rb');
+        if ($fh === false) {
+            throw new \RuntimeException(sprintf(
+                'Unable to open the droid binary file. Please check read permissions for %s.',
+                $candidatePath
+            ));
+        }
+        fclose($fh);
+
+        return $candidatePath;
     }
 }

--- a/src/Command/TargetRunCommand.php
+++ b/src/Command/TargetRunCommand.php
@@ -11,7 +11,6 @@ use RuntimeException;
 use Droid\Remote\Enabler;
 use Droid\Remote\Synchroniser;
 use Droid\TaskRunner;
-use Droid\Remote\Droid\Remote;
 
 class TargetRunCommand extends Command
 {

--- a/src/Loader/YamlLoader.php
+++ b/src/Loader/YamlLoader.php
@@ -101,32 +101,32 @@ class YamlLoader
     private function loadInventory(Inventory $inventory, $data)
     {
         if (isset($data['hosts'])) {
-            foreach ($data['hosts'] as $hostName => $data) {
+            foreach ($data['hosts'] as $hostName => $hostData) {
                 $host = new Host($hostName);
-                if ($data) {
-                    foreach ($data as $key => $value) {
+                if ($hostData) {
+                    foreach ($hostData as $key => $value) {
                         switch ($key) {
                             case 'variables':
-                                $this->loadVariables($data, $host);
+                                $this->loadVariables($hostData, $host);
                                 break;
                             case 'address':
-                                $host->setAddress($data[$key]);
+                                $host->setAddress($hostData[$key]);
                                 break;
                             case 'username':
-                                $host->setUsername($data[$key]);
+                                $host->setUsername($hostData[$key]);
                                 break;
                             case 'password':
-                                $host->setPassword($data[$key]);
+                                $host->setPassword($hostData[$key]);
                                 break;
                             case 'auth':
-                                $host->setAuth($data[$key]);
+                                $host->setAuth($hostData[$key]);
                                 break;
                             case 'keyfile':
-                                $filename = Utils::absoluteFilename($data[$key]);
+                                $filename = Utils::absoluteFilename($hostData[$key]);
                                 $host->setKeyFile($filename);
                                 break;
                             case 'keypass':
-                                $host->setKeyPass($data[$key]);
+                                $host->setKeyPass($hostData[$key]);
                                 break;
                             default:
                                 throw new RuntimeException("Unknown host property: " . $key);

--- a/src/Loader/YamlLoader.php
+++ b/src/Loader/YamlLoader.php
@@ -101,55 +101,88 @@ class YamlLoader
     private function loadInventory(Inventory $inventory, $data)
     {
         if (isset($data['hosts'])) {
-            foreach ($data['hosts'] as $hostName => $hostData) {
-                $host = new Host($hostName);
-                if ($hostData) {
-                    foreach ($hostData as $key => $value) {
-                        switch ($key) {
-                            case 'variables':
-                                $this->loadVariables($hostData, $host);
-                                break;
-                            case 'address':
-                                $host->setAddress($hostData[$key]);
-                                break;
-                            case 'username':
-                                $host->setUsername($hostData[$key]);
-                                break;
-                            case 'password':
-                                $host->setPassword($hostData[$key]);
-                                break;
-                            case 'auth':
-                                $host->setAuth($hostData[$key]);
-                                break;
-                            case 'keyfile':
-                                $filename = Utils::absoluteFilename($hostData[$key]);
-                                $host->setKeyFile($filename);
-                                break;
-                            case 'keypass':
-                                $host->setKeyPass($hostData[$key]);
-                                break;
-                            default:
-                                throw new RuntimeException("Unknown host property: " . $key);
+            $this->loadHosts($inventory, $data['hosts']);
+        }
+        if (isset($data['groups'])) {
+            $this->loadHostGroups($inventory, $data['groups']);
+        }
+    }
+
+    private function loadHosts(Inventory $inventory, $hosts)
+    {
+        $want_gateway = array();
+        foreach ($hosts as $hostName => $hostData) {
+            $host = new Host($hostName);
+            $inventory->addHost($host);
+            if (!$hostData) {
+                continue;
+            }
+            foreach ($hostData as $key => $value) {
+                switch ($key) {
+                    case 'variables':
+                        $this->loadVariables($hostData, $host);
+                        break;
+                    case 'address':
+                        $host->setAddress($value);
+                        break;
+                    case 'username':
+                        $host->setUsername($value);
+                        break;
+                    case 'password':
+                        $host->setPassword($value);
+                        break;
+                    case 'auth':
+                        $host->setAuth($value);
+                        break;
+                    case 'keyfile':
+                        $host->setKeyFile(Utils::absoluteFilename($value));
+                        break;
+                    case 'keypass':
+                        $host->setKeyPass($value);
+                        break;
+                    case 'ssh_options':
+                        $host->setSshOptions($value);
+                        break;
+                    case 'ssh_gateway':
+                        if (! $inventory->hasHost($value)) {
+                            $want_gateway[$hostName] = $value;
+                            break;
                         }
-                    }
+                        $host->setSshGateway($inventory->getHost($value));
+                        break;
+                    default:
+                        throw new RuntimeException("Unknown host property: " . $key);
                 }
-                $inventory->addHost($host);
             }
         }
-        
-        if (isset($data['groups'])) {
-            foreach ($data['groups'] as $groupName => $groupNode) {
-                $group = new HostGroup($groupName);
-                foreach ($groupNode['hosts'] as $hostName) {
-                    if (!$inventory->hasHost($hostName)) {
-                        throw new RuntimeException("Group $groupName refers to undefined host: $hostName");
-                    }
-                    $host = $inventory->getHost($hostName);
-                    $group->addHost($host);
-                }
-                $this->loadVariables($groupNode, $group);
-                $inventory->addHostGroup($group);
+        foreach ($want_gateway as $want => $gateway) {
+            if (! $inventory->hasHost($gateway)) {
+                throw new RuntimeException(sprintf(
+                    'Host "%s" requires an unknown host "%s" as its ssh gateway.',
+                    $want,
+                    $gateway
+                ));
             }
+            $inventory
+                ->getHost($want)
+                ->setSshGateway($inventory->getHost($gateway))
+            ;
+        }
+    }
+
+    private function loadHostGroups(Inventory $inventory, $groups)
+    {
+        foreach ($groups as $groupName => $groupNode) {
+            $group = new HostGroup($groupName);
+            foreach ($groupNode['hosts'] as $hostName) {
+                if (!$inventory->hasHost($hostName)) {
+                    throw new RuntimeException("Group $groupName refers to undefined host: $hostName");
+                }
+                $host = $inventory->getHost($hostName);
+                $group->addHost($host);
+            }
+            $this->loadVariables($groupNode, $group);
+            $inventory->addHostGroup($group);
         }
     }
     

--- a/src/Model/Exception/HostException.php
+++ b/src/Model/Exception/HostException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Droid\Model\Exception;
+
+/**
+ * RuntimeException which identifies a host in the message.
+ */
+class HostException extends \RuntimeException
+{
+    public function __construct(
+        $host = null, $message = null, $code = null, $previous = null
+    ) {
+        $message = sprintf(
+            '[%s] %s',
+            $host ? (string) $host : 'Unknown host',
+            $message ?: 'No Message'
+        );
+        return parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Model/Host.php
+++ b/src/Model/Host.php
@@ -4,7 +4,11 @@ namespace Droid\Model;
 
 use RuntimeException;
 
-class Host
+use Droid\Remote\AbleInterface;
+use Droid\Remote\AbleTrait;
+use Droid\Remote\SshClientTrait;
+
+class Host implements AbleInterface
 {
     private $name;
     private $address;
@@ -14,9 +18,11 @@ class Host
     private $keyFile;
     private $keyPass;
     private $auth;
-    
+
+    use AbleTrait;
+    use SshClientTrait;
     use VariableTrait;
-    
+
     public function __construct($name)
     {
         $this->name = $name;
@@ -25,84 +31,84 @@ class Host
         $this->username = 'root';
         $this->auth = 'agent';
     }
-    
+
     public function getName()
     {
         return $this->name;
     }
-    
+
     public function getAddress()
     {
         return $this->address;
     }
-    
+
     public function setAddress($address)
     {
         $this->address = $address;
         return $this;
     }
-    
-    
+
+
     public function getPort()
     {
         return $this->port;
     }
-    
+
     public function setPort($port)
     {
         $this->port = $port;
         return $this;
     }
-    
+
     public function getUsername()
     {
         return $this->username;
     }
-    
+
     public function setUsername($username)
     {
         $this->username = $username;
         return $this;
     }
-    
+
     public function getPassword()
     {
         return $this->password;
     }
-    
+
     public function setPassword($password)
     {
         $this->password = $password;
         return $this;
     }
-    
+
     public function getAuth()
     {
         return $this->auth;
     }
-    
+
     public function setAuth($auth)
     {
         $this->auth = $auth;
         return $this;
     }
-    
+
     public function getKeyFile()
     {
         return $this->keyFile;
     }
-    
+
     public function setKeyFile($keyFile)
     {
         $this->keyFile = $keyFile;
         return $this;
     }
-    
+
     public function getKeyPass()
     {
         return $this->keyPass;
     }
-    
+
     public function setKeyPass($keyPass)
     {
         $this->keyPass = $keyPass;

--- a/src/Model/Inventory.php
+++ b/src/Model/Inventory.php
@@ -38,7 +38,15 @@ class Inventory
     {
         $this->hostGroups[$hostGroup->getName()] = $hostGroup;
     }
-    
+
+    public function getHostGroup($name)
+    {
+        if (!$this->hasHostGroup($name)) {
+            throw new RuntimeException("No such host group: " . $name);
+        }
+        return $this->hostGroups[$name];
+    }
+
     public function hasHostGroup($name)
     {
         return isset($this->hostGroups[$name]);
@@ -52,8 +60,7 @@ class Inventory
     public function getHostsByName($name)
     {
         if ($this->hasHostGroup($name)) {
-            $hosts = $this->getHostGroup($name);
-            return $hosts;
+            return $this->getHostGroup($name)->getHosts();
         }
         $hosts = [];
         if ($this->hasHost($name)) {

--- a/src/Remote/AbleInterface.php
+++ b/src/Remote/AbleInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Droid\Remote;
+
+/**
+ * Implementers of AbleInterface provide means to be marked as being able to
+ * remotely execute droid command and provide access to pre-configured SSH and
+ * Secure Copy clients.
+ */
+interface AbleInterface
+{
+    /**
+     * Mark the object as being able to remotely execute droid commands.
+     */
+    public function able();
+
+    /**
+     * Mark the object as being unable to remotely execute droid commands.
+     */
+    public function unable();
+
+    /**
+     * Find out whether or not the object has been marked as being able to
+     * remotely execute droid commands.
+     *
+     * @return boolean
+     */
+    public function enabled();
+
+    /**
+     * Get an SSH client, configured for connecting to a particular host.
+     *
+     * @return \SSHClient\Client\ClientInterface
+     */
+    public function getSshClient();
+
+    /**
+     * Get an Secure Copy client, configured for connecting to a particular host.
+     *
+     * @return \SSHClient\Client\ClientInterface
+     */
+    public function getScpClient();
+
+    /**
+     * Get the name of the object.
+     *
+     * @return string
+     */
+    public function getName();
+}

--- a/src/Remote/AbleTrait.php
+++ b/src/Remote/AbleTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Droid\Remote;
+
+/**
+ * Provide methods to mark an object as being able (or not) to remotely execute
+ * remote droid commands and to determine whether or not the object is enabled.
+ */
+trait AbleTrait
+{
+    protected $able = false;
+
+    public function able()
+    {
+        $this->able = true;
+    }
+
+    public function unable()
+    {
+        $this->able = false;
+    }
+
+    public function enabled()
+    {
+        return $this->able === true;
+    }
+}

--- a/src/Remote/EnablementException.php
+++ b/src/Remote/EnablementException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Droid\Remote;
+
+use Droid\Model\Exception\HostException;
+
+/**
+ * RuntimeException thrown in the course of enabling an object to remotely
+ * execute droid commands.
+ */
+class EnablementException extends HostException
+{
+    public function __construct(
+        $host = null, $message = null, $code = null, $previous = null
+    ) {
+        $message = sprintf(
+            'Unable to run remote commands: %s',
+            $message ?: 'No Message'
+        );
+        return parent::__construct($host, $message, $code, $previous);
+    }
+}

--- a/src/Remote/Enabler.php
+++ b/src/Remote/Enabler.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Droid\Remote;
+
+/**
+ * Enable remote execution of droid commands.
+ *
+ * This implementation asserts that a high enough version of PHP is installed
+ * on a host before calling on SynchroniserInterface to arrange for droid to be
+ * made available on the host.
+ */
+class Enabler implements EnablerInterface
+{
+    private $minPhpVersion = 50509;
+
+    public function __construct(SynchroniserInterface $synchroniser)
+    {
+        $this->synchroniser = $synchroniser;
+    }
+
+    public function enable(AbleInterface $host)
+    {
+        $host->unable();
+
+        $this->assertPhpVersion($host->getSshClient(), $host->getName());
+
+        try {
+            $this->synchroniser->sync($host);
+        } catch (SynchronisationException $e) {
+            throw new EnablementException(
+                $host->getName(), 'Failure during binary synchronisation.', null, $e
+            );
+        }
+
+        $host->able();
+    }
+
+    private function assertPhpVersion($ssh, $hostname)
+    {
+        $ssh->exec(array('php', '-r', '"echo PHP_VERSION_ID;"'));
+        if ($ssh->getExitCode()) {
+            throw new EnablementException(
+                $hostname, 'Unable to check remote PHP version. Is PHP installed?'
+            );
+        }
+        $version = trim($ssh->getOutput());
+        if ($version < $this->minPhpVersion) {
+            throw new EnablementException($hostname, sprintf(
+                'The remotely installed version of PHP is too low. Got %s; Expected PHP >= %d.',
+                $version,
+                $this->minPhpVersion
+            ));
+        }
+    }
+}

--- a/src/Remote/EnablerInterface.php
+++ b/src/Remote/EnablerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Droid\Remote;
+
+/**
+ * Enable remote execution of droid commands.
+ */
+interface EnablerInterface
+{
+    /**
+     * Enable droid execution on the supplied remote host.
+     *
+     * @param AbleInterface $host
+     */
+    public function enable(AbleInterface $host);
+}

--- a/src/Remote/SshClientTrait.php
+++ b/src/Remote/SshClientTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Droid\Remote;
+
+use SSHClient\ClientBuilder\ClientBuilder;
+
+/**
+ * Provide means to build pre-configured SSH and Secure Copy clients.
+ */
+trait SshClientTrait
+{
+    protected $sshClientBuilder;
+
+    /**
+     * @return \SSHClient\Client\Client
+     */
+    public function getSshClient()
+    {
+        return $this->getBuilder()->buildClient();
+    }
+
+    /**
+     * @return \SSHClient\Client\Client
+     */
+    public function getScpClient()
+    {
+        return $this->getBuilder()->buildSecureCopyClient();
+    }
+
+    /**
+     * @return \SSHClient\ClientBuilder\ClientBuilder
+     */
+    private function getBuilder()
+    {
+        if (! $this->sshClientBuilder) {
+            $this->sshClientBuilder = new ClientBuilder(new SshConfig($this));
+        }
+        return $this->sshClientBuilder;
+    }
+}

--- a/src/Remote/SshClientTrait.php
+++ b/src/Remote/SshClientTrait.php
@@ -4,19 +4,23 @@ namespace Droid\Remote;
 
 use SSHClient\ClientBuilder\ClientBuilder;
 
+use Droid\Model\Host;
+
 /**
  * Provide means to build pre-configured SSH and Secure Copy clients.
  */
 trait SshClientTrait
 {
     protected $sshClientBuilder;
+    protected $sshGateway;
+    protected $sshOptions = array();
 
     /**
      * @return \SSHClient\Client\Client
      */
     public function getSshClient()
     {
-        return $this->getBuilder()->buildClient();
+        return $this->getSshBuilder()->buildClient();
     }
 
     /**
@@ -24,17 +28,63 @@ trait SshClientTrait
      */
     public function getScpClient()
     {
-        return $this->getBuilder()->buildSecureCopyClient();
+        return $this->getSshBuilder()->buildSecureCopyClient();
     }
 
     /**
      * @return \SSHClient\ClientBuilder\ClientBuilder
      */
-    private function getBuilder()
+    public function getSshBuilder()
     {
         if (! $this->sshClientBuilder) {
             $this->sshClientBuilder = new ClientBuilder(new SshConfig($this));
         }
         return $this->sshClientBuilder;
+    }
+
+    /**
+     * Get SSH Options as an array of option name to option value, suitable as
+     * OpenSSH "-o" options.
+     *
+     * @return array
+     */
+    public function getSshOptions()
+    {
+        return $this->sshOptions;
+    }
+
+    /**
+     * Set OpenSSH "-o" options.
+     *
+     * @param array $options
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function setSshOptions($options)
+    {
+        if (!is_array($options)) {
+            throw new \UnexpectedValueException('Expected an array of options.');
+        }
+        $this->sshOptions = $options;
+    }
+
+    /**
+     * Get an SSH gateway Host.
+     *
+     * @return \Droid\Model\Host
+     */
+    public function getSshGateway()
+    {
+        return $this->sshGateway;
+    }
+
+    /**
+     * Set an SSH gateway Host.
+     *
+     * @param \Droid\Model\Host $gatewayHost
+     */
+    public function setSshGateway(Host $gatewayHost)
+    {
+        $this->sshGateway = $gatewayHost;
     }
 }

--- a/src/Remote/SshConfig.php
+++ b/src/Remote/SshConfig.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Droid\Remote;
+
+use SSHClient\ClientConfiguration\ClientConfiguration;
+
+use Droid\Model\Host;
+
+/**
+ * Extends ClientConfiguration to extract SSH configuration values from a Host.
+ */
+class SshConfig extends ClientConfiguration
+{
+    protected $host;
+
+    public function __construct(Host $host)
+    {
+        $this->host = $host;
+        return parent::__construct($host->getName(), $host->getUsername());
+    }
+
+    public function getOptions()
+    {
+        if ($this->options === false) {
+            return array();
+        }
+        if (empty($this->options)) {
+            $opts = array();
+            if ($this->host->getKeyFile()) {
+                $opts['IdentityFile'] = $this->host->getKeyFile();
+                $opts['IdentitiesOnly'] = 'yes';
+            }
+            if ($this->host->getPort() != 22) {
+                $opts['Port'] = $this->host->getPort();
+            }
+            $this->options = $opts;
+        }
+        return $this->options;
+    }
+}

--- a/src/Remote/SshConfig.php
+++ b/src/Remote/SshConfig.php
@@ -21,20 +21,31 @@ class SshConfig extends ClientConfiguration
 
     public function getOptions()
     {
-        if ($this->options === false) {
-            return array();
-        }
         if (empty($this->options)) {
             $opts = array();
             if ($this->host->getKeyFile()) {
                 $opts['IdentityFile'] = $this->host->getKeyFile();
                 $opts['IdentitiesOnly'] = 'yes';
             }
-            if ($this->host->getPort() != 22) {
+            if ($this->host->getPort() && $this->host->getPort() != 22) {
                 $opts['Port'] = $this->host->getPort();
+            }
+            if ($this->host->getSshGateway()) {
+                $opts['ProxyCommand'] = $this
+                    ->buildProxyCommand($this->host->getSshGateway())
+                ;
+            }
+            if (is_array($this->host->getSshOptions())) {
+                $opts = array_merge($opts, $this->host->getSshOptions());
             }
             $this->options = $opts;
         }
         return $this->options;
+    }
+
+    private function buildProxyCommand(Host $gatewayHost)
+    {
+        $gwPrefix = $gatewayHost->getSshBuilder()->buildSSHPrefix();
+        return sprintf('%s nc %%h %%p', implode(' ', $gwPrefix));
     }
 }

--- a/src/Remote/SynchronisationException.php
+++ b/src/Remote/SynchronisationException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Droid\Remote;
+
+use Droid\Model\Exception\HostException;
+
+/**
+ * RuntimeException thrown in the course of synchronising versions of the droid
+ * executable on remote hosts.
+ */
+class SynchronisationException extends HostException
+{
+    public function __construct(
+        $host = null, $message = null, $code = null, $previous = null
+    ) {
+        $message = sprintf(
+            'Unable to synchronise remote droid binary: %s',
+            $message ?: 'No Message'
+        );
+        return parent::__construct($host, $message, $code, $previous);
+    }
+}

--- a/src/Remote/Synchroniser.php
+++ b/src/Remote/Synchroniser.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Droid\Remote;
+
+use Droid\Application;
+
+/**
+ * Ensure that a remote host has the same version of droid as the local host.
+ *
+ * This implementation uses the sha1 digest of the content of the droid
+ * executable to determine whether two versions differ. It uses SSH and Secure
+ * Copy clients provided by the Host model.
+ */
+class Synchroniser implements SynchroniserInterface
+{
+    protected $localDroidPath;
+    protected $remoteDroidPath = '/tmp/';
+
+    /**
+     * @param string $localDroidPath Path to the local droid binary file
+     */
+    public function __construct($localDroidPath = null)
+    {
+        $this->localDroidPath = $localDroidPath;
+    }
+
+    public function sync(AbleInterface $host)
+    {
+        if (! $this->localDroidPath) {
+            throw new SynchronisationException(
+                $host->getName(), 'Local droid is missing.'
+            );
+        }
+
+        $synchronised = $this->remoteDroidMatches(
+            $host, $this->getDroidBinaryDigest()
+        );
+
+        if (! $synchronised) {
+            $this->uploadDroid($host, 300);
+        }
+    }
+
+    private function getDroidBinaryDigest()
+    {
+        $digest = @sha1_file($this->localDroidPath); # suppress E_WARNING on noexist
+        if ($digest === false) {
+            throw new SynchronisationException(null, sprintf(
+                'Unable to read the droid binary file %s.',
+                 $this->localDroidPath
+            ));
+        }
+        return $digest;
+    }
+
+    private function remoteDroidMatches($host, $digest)
+    {
+        $ssh = $host
+            ->getSshClient()
+            ->exec(array(sprintf(
+                'echo "%s %s" > %s.sha1 && sha1sum --status -c %s.sha1',
+                $digest,
+                $this->remoteDroidPath . Application::DROID_BIN_NAME,
+                $this->remoteDroidPath . Application::DROID_BIN_NAME,
+                $this->remoteDroidPath . Application::DROID_BIN_NAME
+            )))
+        ;
+        return $ssh->getExitCode() == 0;
+    }
+
+    private function uploadDroid($host, $timeout)
+    {
+        $scp = $host->getScpClient();
+        $scp->copy(
+            $this->localDroidPath,
+            $scp->getRemotePath($this->remoteDroidPath),
+            null,
+            $timeout
+        );
+        if ($scp->getExitCode()) {
+            throw new SynchronisationException($host->getName(), sprintf(
+                'Unable to upload droid: "%s".',
+                implode(' ', explode("\n", $scp->getErrorOutput())))
+            );
+        }
+    }
+}

--- a/src/Remote/Synchroniser.php
+++ b/src/Remote/Synchroniser.php
@@ -47,7 +47,7 @@ class Synchroniser implements SynchroniserInterface
         if ($digest === false) {
             throw new SynchronisationException(null, sprintf(
                 'Unable to read the droid binary file %s.',
-                 $this->localDroidPath
+                $this->localDroidPath
             ));
         }
         return $digest;
@@ -80,8 +80,8 @@ class Synchroniser implements SynchroniserInterface
         if ($scp->getExitCode()) {
             throw new SynchronisationException($host->getName(), sprintf(
                 'Unable to upload droid: "%s".',
-                implode(' ', explode("\n", $scp->getErrorOutput())))
-            );
+                implode(' ', explode("\n", $scp->getErrorOutput()))
+            ));
         }
     }
 }

--- a/src/Remote/SynchroniserInterface.php
+++ b/src/Remote/SynchroniserInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Droid\Remote;
+
+/**
+ * Ensure that a remote host has the same version of droid as the local host.
+ */
+interface SynchroniserInterface
+{
+    /**
+     * Upload the local droid executable when its content differs from that of
+     * the remote droid executable.
+     *
+     * @param AbleInterface $host
+     *
+     * @throws \Droid\Remote\SynchronisationException
+     */
+    public function sync(AbleInterface $host);
+}

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -2,19 +2,17 @@
 
 namespace Droid;
 
+use RuntimeException;
+
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Application as App;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
-use Droid\Model\Host;
-use Droid\Remote\EnablerInterface;
-use RuntimeException;
-use SSHClient\ClientConfiguration\ClientConfiguration;
-use SSHClient\ClientBuilder\ClientBuilder;
-use Droid\Remote\EnablementException;
 use Symfony\Component\Process\Process;
 
+use Droid\Remote\EnablementException;
+use Droid\Remote\EnablerInterface;
 
 class TaskRunner
 {

--- a/test/Droid/AutoloaderAwareTestCase.php
+++ b/test/Droid/AutoloaderAwareTestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Droid\Test;
+
+/**
+ * A base test case which makes an autoloader available as a protected property.
+ * The autoloader is obtained from the phpunit bootstrap.
+ */
+abstract class AutoloaderAwareTestCase extends \PHPUnit_Framework_TestCase
+{
+    protected $autoloader;
+
+    public function __construct($name = null, array $data = array(), $dataName = '')
+    {
+        global $droid_test_autoloader;
+        $this->autoloader = $droid_test_autoloader;
+        return parent::__construct($name, $data, $dataName);
+    }
+}

--- a/test/Droid/Remote/EnablerTest.php
+++ b/test/Droid/Remote/EnablerTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Droid\Test\Remote;
+
+use Droid\Remote\AbleInterface;
+use Droid\Remote\SynchronisationException;
+use Droid\Remote\Enabler;
+use Droid\Remote\SynchroniserInterface;
+
+use SSHClient\Client\ClientInterface;
+
+class EnablerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $enabler;
+    protected $synchroniser;
+    protected $host;
+    protected $sshClient;
+    protected $scpClient;
+
+    public function setUp()
+    {
+        $this->synchroniser = $this
+            ->getMockBuilder(SynchroniserInterface::class)
+            ->setConstructorArgs(array('some_path'))
+            ->getMock()
+        ;
+        $this->host = $this
+            ->getMockBuilder(AbleInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass()
+        ;
+        $this->sshClient = $this
+            ->getMockBuilder(ClientInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->scpClient = $this
+            ->getMockBuilder(ClientInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->enabler = new Enabler($this->synchroniser);
+    }
+
+    /**
+     * @expectedException \Droid\Remote\EnablementException
+     * @expectedExceptionMessage Unable to check remote PHP version
+     */
+    public function testEnableFailsWhenSshExecFails()
+    {
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('unable')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('test_host')
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('exec')
+            ->with($this->equalTo(array('php', '-r', '"echo PHP_VERSION_ID;"')))
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(1) # exec failed
+        ;
+        $this
+            ->host
+            ->expects($this->never())
+            ->method('able')
+        ;
+
+        $this->enabler->enable($this->host);
+    }
+
+    /**
+     * @expectedException \Droid\Remote\EnablementException
+     * @expectedExceptionMessage version of PHP is too low
+     */
+    public function testEnableFailsWhenPhpVersionTooLow()
+    {
+        $this
+            ->host
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->host
+            ->method('getName')
+            ->willReturn('test_host')
+        ;
+        $this
+            ->sshClient
+            ->method('getExitCode')
+            ->willReturn(0) # exec ok
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn("50334\n")
+        ;
+        $this
+            ->host
+            ->expects($this->never())
+            ->method('able')
+        ;
+
+        $this->enabler->enable($this->host);
+    }
+
+    /**
+     * @expectedException \Droid\Remote\EnablementException
+     * @expectedExceptionMessage Failure during binary synchronisation
+     */
+    public function testEnableFailsWhenSynchronisationFails()
+    {
+        $this
+            ->host
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->host
+            ->method('getName')
+            ->willReturn('test_host')
+        ;
+        $this
+            ->sshClient
+            ->method('getExitCode')
+            ->willReturn(0) # exec ok
+        ;
+        $this
+            ->sshClient
+            ->method('getOutput')
+            ->willReturn("50509\n")
+        ;
+        $this
+            ->synchroniser
+            ->expects($this->once())
+            ->method('sync')
+            ->with($this->host)
+            ->willThrowException(
+                new SynchronisationException('test_host', 'test_message')
+            )
+        ;
+        $this
+            ->host
+            ->expects($this->never())
+            ->method('able')
+        ;
+
+        $this->enabler->enable($this->host);
+    }
+
+    public function testEnableSucceeds()
+    {
+        $this
+            ->host
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->host
+            ->method('getName')
+            ->willReturn('test_host')
+        ;
+        $this
+            ->sshClient
+            ->method('getExitCode')
+            ->willReturn(0) # exec ok
+        ;
+        $this
+            ->sshClient
+            ->method('getOutput')
+            ->willReturn("50509\n")
+        ;
+        $this
+            ->synchroniser
+            ->method('sync')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('able')
+        ;
+
+        $this->enabler->enable($this->host);
+    }
+}

--- a/test/Droid/Remote/SshConfigTest.php
+++ b/test/Droid/Remote/SshConfigTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Droid\Test\Remote;
+
+use SSHClient\Client\ClientInterface;
+use SSHClient\ClientBuilder\ClientBuilder;
+use Symfony\Component\Process\Process;
+
+use Droid\Model\Host;
+use Droid\Remote\SshConfig;
+
+class SshConfigTest extends \PHPUnit_Framework_TestCase
+{
+    protected $host;
+    protected $sshClient;
+    protected $sshClientBuilder;
+
+    public function setUp()
+    {
+        $this->host = $this
+            ->getMockBuilder(Host::class)
+            ->setConstructorArgs(array('test_host'))
+            ->getMock()
+        ;
+    }
+
+    public function testMinimalConfig()
+    {
+        $this
+            ->host
+            ->expects($this->at(0))
+            ->method('getName')
+        ;
+        $this
+            ->host
+            ->expects($this->at(1))
+            ->method('getUsername')
+        ;
+
+        new SshConfig($this->host);
+    }
+
+    public function testKeyfileInConfig()
+    {
+        $this
+            ->host
+            ->method('getKeyFile')
+            ->willReturn('/path/to/some/file')
+        ;
+
+        $config = new SshConfig($this->host);
+        $builder = new ClientBuilder($config);
+        $builder->buildSSHPrefix();
+
+        $this->assertArraySubset(
+            array(
+                'IdentityFile' => '/path/to/some/file',
+                'IdentitiesOnly' => 'yes',
+            ),
+            $config->getOptions()
+        );
+    }
+
+    public function testStandardPortConfig()
+    {
+        $this
+            ->host
+            ->method('getPort')
+            ->willReturn(22)
+        ;
+
+        $config = new SshConfig($this->host);
+        $builder = new ClientBuilder($config);
+        $builder->buildSSHPrefix();
+
+        $this->assertArrayNotHasKey('Port', $config->getOptions());
+    }
+
+    public function testNonStandardPortConfig()
+    {
+        $this
+            ->host
+            ->method('getPort')
+            ->willReturn(10022)
+        ;
+
+        $config = new SshConfig($this->host);
+        $builder = new ClientBuilder($config);
+        $builder->buildSSHPrefix();
+
+        $this->assertArraySubset(
+            array(
+                'Port' => 10022,
+            ),
+            $config->getOptions()
+        );
+    }
+}

--- a/test/Droid/Remote/SynchroniserTest.php
+++ b/test/Droid/Remote/SynchroniserTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Droid\Test\Remote;
+
+use Droid\Remote\AbleInterface;
+use Droid\Remote\SynchronisationException;
+use Droid\Remote\Synchroniser;
+
+use SSHClient\Client\ClientInterface;
+
+class SynchroniserTest extends \PHPUnit_Framework_TestCase
+{
+    protected $host;
+    protected $sshClient;
+    protected $scpClient;
+
+    public function setUp()
+    {
+        $this->host = $this
+            ->getMockBuilder(AbleInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass()
+        ;
+        $this->sshClient = $this
+            ->getMockBuilder(ClientInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->scpClient = $this
+            ->getMockBuilder(ClientInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @expectedException \Droid\Remote\SynchronisationException
+     * @expectedExceptionMessage Local droid is missing
+     */
+    public function testSyncFailsWhenLocalDroidMissing()
+    {
+        $synchroniser = new Synchroniser;
+        $synchroniser->sync($this->host);
+    }
+
+    /**
+     * @expectedException \Droid\Remote\SynchronisationException
+     * @expectedExceptionMessage Unable to read the droid binary file /tmp/not-a-file.
+     */
+    public function testSyncFailsWhenLocalDroidUnreadable()
+    {
+        $synchroniser = new Synchroniser('/tmp/not-a-file');
+        $synchroniser->sync($this->host);
+    }
+
+    public function testSyncOccursWhenLocalDroidDiffers()
+    {
+        $localDroidPath = '/tmp/droid-synchroniser-test-file';
+
+        $fh = fopen($localDroidPath, 'w');
+        fwrite($fh, 'droid-synchroniser-test-' . md5('' . rand()));
+        fclose($fh);
+
+        $digest = sha1_file($localDroidPath);
+
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('exec')
+            ->with(array(sprintf(
+                'echo "%s /tmp/droid.phar" > /tmp/droid.phar.sha1 && sha1sum --status -c /tmp/droid.phar.sha1',
+                $digest
+            )))
+            ->willReturnSelf()
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(1) # differs
+        ;
+
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getScpClient')
+            ->willReturn($this->scpClient)
+        ;
+        $this
+            ->scpClient
+            ->expects($this->once())
+            ->method('getRemotePath')
+            ->with('/tmp/')
+            ->willReturn('user@host:/tmp/')
+        ;
+        $this
+            ->scpClient
+            ->expects($this->once())
+            ->method('copy')
+            ->with($localDroidPath, 'user@host:/tmp/')
+            ->willReturnSelf()
+        ;
+        $this
+            ->scpClient
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(0) # copy succeeded
+        ;
+
+        $synchroniser = new Synchroniser($localDroidPath);
+        $synchroniser->sync($this->host);
+
+        return $localDroidPath;
+    }
+
+    /**
+     * @group wip
+     * @depends testSyncOccursWhenLocalDroidDiffers
+     * @expectedException \Droid\Remote\SynchronisationException
+     * @expectedExceptionMessage Unable to upload droid
+     */
+    public function testSyncOccursAndFails($localDroidPath)
+    {
+        $this
+            ->host
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->sshClient
+            ->method('exec')
+            ->willReturnSelf()
+        ;
+        $this
+            ->sshClient
+            ->method('getExitCode')
+            ->willReturn(1) # differs
+        ;
+
+        $this
+            ->host
+            ->method('getScpClient')
+            ->willReturn($this->scpClient)
+        ;
+        $this
+            ->host
+            ->method('getScpPath')
+            ->willReturnArgument(0)
+        ;
+        $this
+            ->scpClient
+            ->method('getRemotePath')
+            ->willReturn('host:/tmp/')
+        ;
+        $this
+            ->scpClient
+            ->method('copy')
+            ->willReturnSelf()
+        ;
+        $this
+            ->scpClient
+            ->method('getExitCode')
+            ->willReturn(1) # copy failed
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('test_host')
+        ;
+        $this
+            ->scpClient
+            ->expects($this->once())
+            ->method('getErrorOutput')
+            ->willReturn('Copy failed - this is only a test!')
+        ;
+
+        $synchroniser = new Synchroniser($localDroidPath);
+        $synchroniser->sync($this->host);
+    }
+
+    /**
+     * @depends testSyncOccursWhenLocalDroidDiffers
+     */
+    public function testSyncSkippedWhenLocalDroidMatches($localDroidPath)
+    {
+        $this
+            ->host
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->sshClient
+            ->method('exec')
+            ->willReturnSelf()
+        ;
+        $this
+            ->sshClient
+            ->method('getExitCode')
+            ->willReturn(0) # digest matched
+        ;
+
+        $this
+            ->host
+            ->expects($this->never())
+            ->method('getScpClient')
+        ;
+
+        $synchroniser = new Synchroniser($localDroidPath);
+        $synchroniser->sync($this->host);
+    }
+}

--- a/test/Droid/TaskRunner/RunRemoteCommandTest.php
+++ b/test/Droid/TaskRunner/RunRemoteCommandTest.php
@@ -119,9 +119,6 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
         $runner->runRemoteCommand($this->command, $this->input, array($this->host));
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testRunRemoteCommandNonZeroExitCode()
     {
         $this
@@ -145,12 +142,12 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
         $this
             ->sshClient
             ->expects($this->once())
-            ->method('exec')
+            ->method('startExec')
             ->with($this->isType('array'))
         ;
         $this
             ->sshClient
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('getExitCode')
             ->willReturn(1)
         ;
@@ -183,7 +180,7 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
         $this
             ->sshClient
             ->expects($this->once())
-            ->method('exec')
+            ->method('startExec')
             ->with($this->isType('array'))
         ;
         $this

--- a/test/Droid/TaskRunner/RunRemoteCommandTest.php
+++ b/test/Droid/TaskRunner/RunRemoteCommandTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Droid\Test;
+
+use Droid\Test\AutoloaderAwareTestCase;
+
+use Droid\Application;
+use Droid\TaskRunner;
+use Droid\Remote\AbleInterface;
+use Droid\Remote\EnablerInterface;
+use Droid\Remote\EnablementException;
+use Droid\Remote\SynchroniserInterface;
+
+use SSHClient\Client\ClientInterface;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RunRemoteCommandTest extends AutoloaderAwareTestCase
+{
+    private $synchroniser;
+    private $enabler;
+    private $output;
+    private $input;
+    private $command;
+    private $host;
+    private $sshClient;
+
+    public function setUp()
+    {
+        $this->synchroniser = $this
+            ->getMockBuilder(SynchroniserInterface::class)
+            ->setConstructorArgs(array('/tmp/droid-remote-command-test'))
+            ->getMock()
+        ;
+        $this->enabler = $this
+            ->getMockBuilder(EnablerInterface::class)
+            ->setConstructorArgs(array($this->synchroniser))
+            ->getMock()
+        ;
+        $this->output = $this
+            ->getMockBuilder(OutputInterface::class)
+            ->getMock()
+        ;
+        $this->input = $this
+            ->getMockBuilder(ArrayInput::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->command = $this
+            ->getMockBuilder(Command::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->host = $this
+            ->getMockBuilder(AbleInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass()
+        ;
+        $this->sshClient = $this
+            ->getMockBuilder(ClientInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Unable to run remote command
+     */
+    public function testRunRemoteCommandCannotUploadDroid()
+    {
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('enabled')
+            ->willReturn(false)
+        ;
+        $this
+            ->enabler
+            ->expects($this->once())
+            ->method('enable')
+            ->willThrowException(new EnablementException)
+        ;
+        $this
+            ->host
+            ->expects($this->never())
+            ->method('getSshClient')
+        ;
+
+        $app = new Application($this->autoloader);
+        $runner = new TaskRunner($app, $this->output, $this->enabler);
+        $runner->runRemoteCommand($this->command, $this->input, array($this->host));
+    }
+
+    public function testRunRemoteCommandNeedsNotUploadDroid()
+    {
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('enabled')
+            ->willReturn(true)
+        ;
+        $this
+            ->enabler
+            ->expects($this->never())
+            ->method('enable')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+
+        $app = new Application($this->autoloader);
+        $runner = new TaskRunner($app, $this->output, $this->enabler);
+        $runner->runRemoteCommand($this->command, $this->input, array($this->host));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testRunRemoteCommandNonZeroExitCode()
+    {
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('enabled')
+            ->willReturn(false)
+        ;
+        $this
+            ->enabler
+            ->expects($this->once())
+            ->method('enable')
+            ->with($this->host)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('exec')
+            ->with($this->isType('array'))
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(1)
+        ;
+
+        $app = new Application($this->autoloader);
+        $runner = new TaskRunner($app, $this->output, $this->enabler);
+        $runner->runRemoteCommand($this->command, $this->input, array($this->host));
+    }
+
+    public function testRunRemoteCommandGoodResult()
+    {
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('enabled')
+            ->willReturn(false)
+        ;
+        $this
+            ->enabler
+            ->expects($this->once())
+            ->method('enable')
+            ->with($this->host)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('exec')
+            ->with($this->isType('array'))
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(0)
+        ;
+
+        $app = new Application($this->autoloader);
+        $runner = new TaskRunner($app, $this->output, $this->enabler);
+        $runner->runRemoteCommand($this->command, $this->input, array($this->host));
+    }
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Require the composer-generated autoloader.
+ */
+$droid_test_autoloader = require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
- Remote hosts are "enabled" to run droid commands: Enabler and Synchroniser are responsible for checking PHP version suitability and uploading droid.phar.
- Replaced phpseclib NET/SSH with ssh-client which provides Client.{exec,startExec,copy,startCopy} (the start\* methods being the non-blocking counterparts to exec and copy)
- Execute remote droid commands in non-blocking mode (after "enabling" the targeted hosts in blocking-mode)
- Support for ProxyCommand, set either using `ssh_options` or by setting `ssh_gateway`
## Important note about authentication

ssh-client provides no means for authenticating a user to a host; authentication is handled purely by OpenSSH.  I have been unable to successfully pipe a stored password or key pass phrase to the underlying OpenSSH or agent process and OpenSSH provides does not accept passwords on the command line or through environment variables.

As such, the changes in this PR mean that the documented droid authentication configuration are no longer honoured (but have not been removed).  Essentially, to get the best automation experience, users will want to set-up agent authentication, exactly as is required when using OpenSSH.
