### PR TITLE
Various new features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": ">=5.3.0",
         "droid/droid-model": "~1.0",
+        "psr/log": "^1.0",
         "symfony/property-access": "^3.1",
         "symfony/console": "~2.7",
         "symfony/expression-language": "^3.1",

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,6 +13,7 @@ use Droid\Model\Inventory\Remote\SynchroniserPhar;
 use Droid\Model\Project\Project;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -20,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use Droid\Command\TargetRunCommand;
 use Droid\Loader\YamlLoader;
+use Droid\Logger\LoggerFactory;
 use Droid\Transform\DataStreamTransformer;
 use Droid\Transform\FileTransformer;
 use Droid\Transform\InventoryTransformer;
@@ -101,7 +103,21 @@ class Application extends ConsoleApplication
             exit(1);
         }
 
+        $this->configureOutput($output);
+
         return parent::run($input, $output);
+    }
+
+    private function configureOutput(OutputInterface $output)
+    {
+        $formatter = $output->getFormatter();
+        if (!$formatter) {
+            return;
+        }
+        $formatter->setStyle(
+            'host',
+            new OutputFormatterStyle('black', 'blue', array('reverse'))
+        );
     }
 
     protected function formatErrorMessages($messages)
@@ -185,7 +201,11 @@ class Application extends ConsoleApplication
         }
 
         if ($this->hasProject()) {
-            $runner = new TaskRunner($this, $this->transformer);
+            $runner = new TaskRunner(
+                $this,
+                $this->transformer,
+                new LoggerFactory
+            );
             $enabler = $this->configureHostEnabler();
             if (! $enabler) {
                 # TODO output a warning about not being able to run remote cmds

--- a/src/Command/PingCommand.php
+++ b/src/Command/PingCommand.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Droid\Command;
+
+use Droid\Model\Inventory\Inventory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PingCommand extends Command
+{
+    protected $inventory;
+
+    /**
+     *
+     * @param Inventory $inventory
+     */
+    public function setInventory(Inventory $inventory)
+    {
+        $this->inventory = $inventory;
+        return $this;
+    }
+
+    /**
+     * @return \Droid\Model\Inventory\Inventory
+     */
+    public function getInventory()
+    {
+        return $this->inventory;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('ping')
+            ->setDescription(
+                'Connect to SSH on the specified host, or all hosts in the Inventory.'
+            )
+            ->addArgument(
+                'hostname',
+                InputArgument::OPTIONAL,
+                'The name of a host to ping'
+            )
+            ->setHelp(implode("\n", array(
+                'Connects to and immediately disconnect from the SSH service on a specified Inventory host or all Inventory hosts.',
+                'An SSH connection is attempted only to Inventory hosts having a "keyfile" configured in their entry in the Inventory.'
+            )))
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        if (! $this->getInventory() || ! $this->getInventory()->getHosts()) {
+            throw new RuntimeException('To perform this command I require an Inventory of Hosts.');
+        }
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $hosts = array();
+        if ($input->getArgument('hostname')) {
+            $h = $this->getInventory()->getHost($input->getArgument('hostname'));
+            if (! $h->getKeyFile()) {
+                throw new RuntimeException(
+                    sprintf(
+                        'I cannot ping the host named "%s": there is no "keyfile" (SSH IdentityFile) configured with which to authenticate the "%s" user.',
+                        $h->getName(),
+                        $h->getUsername()
+                    )
+                );
+            }
+            $hosts[] = $h;
+        } else {
+            # simply ignore hosts without a keyfile
+            $hosts = array_filter(
+                $this->getInventory()->getHosts(),
+                function ($x) {
+                    return $x->getKeyFile() !== null;
+                }
+            );
+        }
+
+        $output->writeln(
+            sprintf(
+                'I attempt to Ping %d host%s.',
+                sizeof($hosts),
+                sizeof($hosts) == 1 ? '' : 's'
+            )
+        );
+
+        foreach ($hosts as $host) {
+            $ssh = $host->getSshClient();
+            $output->writeln(
+                sprintf('<host>%s</> Ping.', $host->getName())
+            );
+            $ssh->exec(array('/bin/true'));
+            if ($ssh->getExitCode()) {
+                $output->writeln(
+                    sprintf(
+                        '<host>%s</> Ping fail (code %d):-',
+                        $host->getName(),
+                        $ssh->getExitCode()
+                    )
+                );
+                $output->write($ssh->getErrorOutput(), true);
+            } else {
+                $output->writeln(
+                    sprintf('<host>%s</>  <info>Pong</>.', $host->getName())
+                );
+                $stdout = $ssh->getOutput();
+                if (strlen($stdout)) {
+                    $output->write($stdout, true);
+                }
+                $stderr = $ssh->getErrorOutput();
+                if (strlen($stderr)) {
+                    $output->write($stderr, true);
+                }
+            }
+        }
+
+        $output->writeln('Finished Pinging hosts.');
+    }
+}

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -18,6 +18,7 @@ class DroidPlugin
         $commands[] = new \Droid\Command\GeneratePluginCommand();
         $commands[] = new \Droid\Command\InventoryCommand();
         $commands[] = new \Droid\Command\ModuleInstallCommand();
+        $commands[] = new \Droid\Command\PingCommand;
         return $commands;
     }
 }

--- a/src/Loader/YamlLoader.php
+++ b/src/Loader/YamlLoader.php
@@ -410,6 +410,11 @@ class YamlLoader
                     case 'host_filter':
                         $task->setHostFilter($taskNode[$key]);
                         break;
+                    case 'sudo':
+                        if (is_bool($taskNode[$key])) {
+                            $task->setElevatePrivileges($taskNode[$key]);
+                        }
+                        break;
                     case 'trigger':
                         // TODO: Support array of triggers
                         $task->addTrigger($taskNode[$key]);

--- a/src/Loader/YamlLoader.php
+++ b/src/Loader/YamlLoader.php
@@ -410,6 +410,9 @@ class YamlLoader
                     case 'host_filter':
                         $task->setHostFilter($taskNode[$key]);
                         break;
+                    case 'max_runtime':
+                        $task->setMaxRuntime($taskNode[$key]);
+                        break;
                     case 'sudo':
                         if (is_bool($taskNode[$key])) {
                             $task->setElevatePrivileges($taskNode[$key]);

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Droid\Logger;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+
+/**
+ * PSR-3 compliant console logger.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @link http://www.php-fig.org/psr/psr-3/
+ */
+class ConsoleLogger extends AbstractLogger
+{
+    const INFO = 'info';
+    const ERROR = 'error';
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+    /**
+     * @var array
+     */
+    private $verbosityLevelMap = array(
+        LogLevel::EMERGENCY => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::ALERT => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::ERROR => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::WARNING => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::NOTICE => OutputInterface::VERBOSITY_VERBOSE,
+        LogLevel::INFO => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        LogLevel::DEBUG => OutputInterface::VERBOSITY_DEBUG,
+    );
+    /**
+     * @var array
+     */
+    private $formatLevelMap = array(
+        LogLevel::EMERGENCY => self::ERROR,
+        LogLevel::ALERT => self::ERROR,
+        LogLevel::CRITICAL => self::ERROR,
+        LogLevel::ERROR => self::ERROR,
+        LogLevel::WARNING => self::INFO,
+        LogLevel::NOTICE => self::INFO,
+        LogLevel::INFO => self::INFO,
+        LogLevel::DEBUG => self::INFO,
+    );
+
+    /**
+     * @param OutputInterface $output
+     * @param array           $verbosityLevelMap
+     * @param array           $formatLevelMap
+     */
+    public function __construct(OutputInterface $output, array $verbosityLevelMap = array(), array $formatLevelMap = array())
+    {
+        $this->output = $output;
+        $this->verbosityLevelMap = $verbosityLevelMap + $this->verbosityLevelMap;
+        $this->formatLevelMap = $formatLevelMap + $this->formatLevelMap;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = array())
+    {
+        if (!isset($this->verbosityLevelMap[$level])) {
+            throw new InvalidArgumentException(sprintf('The log level "%s" does not exist.', $level));
+        }
+
+        // Write to the error output if necessary and available
+        if ($this->formatLevelMap[$level] === self::ERROR && $this->output instanceof ConsoleOutputInterface) {
+            $output = $this->output->getErrorOutput();
+        } else {
+            $output = $this->output;
+        }
+
+        if ($output->getVerbosity() >= $this->verbosityLevelMap[$level]) {
+            if (isset($context['host'])) {
+                $output->writeln(
+                    sprintf(
+                        '<%1$s><host>%2$s</> %3$s</%1$s>',
+                        $this->formatLevelMap[$level],
+                        $context['host'],
+                        $this->interpolate($message, $context)
+                    )
+                );
+            } else {
+                $output->writeln(
+                    sprintf(
+                        '<%1$s><wu-tang>Bring da ruckus</> %2$s</%1$s>',
+                        $this->formatLevelMap[$level],
+                        $this->interpolate($message, $context)
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Interpolates context values into the message placeholders.
+     *
+     * @author PHP Framework Interoperability Group
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return string
+     */
+    private function interpolate($message, array $context)
+    {
+        // build a replacement array with braces around the context keys
+        $replace = array();
+        foreach ($context as $key => $val) {
+            if (!is_array($val) && (!is_object($val) || method_exists($val, '__toString'))) {
+                $replace[sprintf('{%s}', $key)] = $val;
+            }
+        }
+
+        // interpolate replacement values into the message and return
+        return strtr($message, $replace);
+    }
+}

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Droid\Logger;
+
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class LoggerFactory
+{
+    public function makeLogger(OutputInterface $output)
+    {
+        return new ConsoleLogger(
+            $output,
+            array(
+                LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+                LogLevel::INFO   => OutputInterface::VERBOSITY_VERBOSE,
+            )
+        );
+    }
+}

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -234,12 +234,15 @@ class TaskRunner
 
     public function runLocalCommand(Task $task, Command $command, ArrayInput $commandInput)
     {
-        //$commandInput->setArgument('command', $command->getName());
-        //$res = $command->run($commandInput, $this->output);
-
-        $argv = $_SERVER['argv'];
-        $filename = $argv[0];
-        $process = new Process($filename . ' ' . $command->getName() . ' ' . (string)$commandInput . ' --ansi');
+        $process = new Process(
+            sprintf(
+                '%s%s %s %s --ansi',
+                $task->getElevatePrivileges() ? 'sudo ' : '',
+                $_SERVER['argv'][0],
+                $command->getName(),
+                (string) $commandInput
+            )
+        );
         if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
             $this->output->writeLn("Full command-line: " . $process->getCommandLine());
         }
@@ -307,10 +310,13 @@ class TaskRunner
                 $runner->taskOutput($task, $type, $buf, $host->getName());
             };
 
-
             $cmd = array(
                 sprintf('cd %s;', $host->getWorkingDirectory()),
-                $host->getDroidCommandPrefix(),
+                sprintf(
+                    '%s%s',
+                    $task->getElevatePrivileges() ? 'sudo ' : '',
+                    $host->getDroidCommandPrefix()
+                ),
                 $command->getName(),
                 (string) $commandInput[$host->getName()],
                 '--ansi'

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -16,22 +16,27 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\Process\Process;
 
+use Droid\Logger\LoggerFactory;
 use Droid\Transform\Transformer;
 
 class TaskRunner
 {
     private $output;
     private $app;
+    private $enabler;
     private $connections = [];
     private $expr;
+    private $loggerFac;
     private $transformer;
 
     public function __construct(
         Application $app,
         Transformer $transformer,
+        LoggerFactory $loggerFactory,
         ExpressionLanguage $expr = null
     ) {
         $this->app = $app;
+        $this->loggerFac = $loggerFactory;
         $this->transformer = $transformer;
         if (! $expr) {
             $this->expr = new ExpressionLanguage;
@@ -49,6 +54,9 @@ class TaskRunner
     public function setOutput(OutputInterface $output)
     {
         $this->output = $output;
+
+        $this->enabler->setLogger($this->loggerFac->makeLogger($output));
+
         return $this;
     }
 
@@ -78,7 +86,7 @@ class TaskRunner
             $commandInput = array();
             foreach ($taskHosts as $host) {
                 $perHostVars = array_merge($variables, array('host' => $host));
-                // Allow host-level variables to override project, module and target variables 
+                // Allow host-level variables to override project, module and target variables
                 $perHostVars = array_merge($perHostVars, $host->getVariables());
                 $commandInput[$host->name] = $this
                     ->prepareCommandInput($command, $task->getArguments(), $perHostVars)
@@ -209,7 +217,7 @@ class TaskRunner
 
     public function taskOutput(Task $task, $type, $buf, $hostname)
     {
-        $fmt = '<fg=black;bg=blue;options=reverse>' . $hostname . '</> %s';
+        $fmt = '<host>' . $hostname . '</> %s';
         if ($type === Process::ERR) {
             $fmt = '<error>' . $hostname . '</error> %s';
         }
@@ -468,8 +476,8 @@ class TaskRunner
                         'Unable to parse Task with_items_filter expression "%s"',
                         $task->getItemFilter()
                     ),
-                null,
-                $e
+                    null,
+                    $e
                 );
             }
         }

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -255,7 +255,10 @@ class TaskRunner
             $this->output->writeLn("Full command-line: " . $process->getCommandLine());
         }
 
-        $process->start();
+        $process
+            ->setTimeout($task->getMaxRuntime())
+            ->start()
+        ;
         $output = $this->output;
         $runner = $this;
         $process->wait(function ($type, $buf) use ($runner, $task, $output) {
@@ -338,9 +341,19 @@ class TaskRunner
                 );
             }
 
+            $max_runtime = null;
+            $unlimited_runtime = false;
+            if ($task->getMaxRuntime() === 0) {
+                $unlimited_runtime = true;
+            } else if ($task->getMaxRuntime()) {
+                $max_runtime = $task->getMaxRuntime();
+            }
+
             $ssh->startExec(
                 $cmd,
-                $outputter
+                $outputter,
+                $max_runtime,
+                $unlimited_runtime
             );
             $running[] = array($host, $ssh);
         }

--- a/test/Droid/Command/PingCommandTest.php
+++ b/test/Droid/Command/PingCommandTest.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace Droid\Test\Command;
+
+use PHPUnit_Framework_TestCase;
+use RuntimeException;
+
+use Droid\Model\Inventory\Host;
+use Droid\Model\Inventory\Inventory;
+use SSHClient\Client\ClientInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use Droid\Command\PingCommand;
+
+class PingCommandTest extends PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $command;
+    protected $host;
+    protected $inventory;
+    protected $ssh;
+    protected $tester;
+
+    protected function setUp()
+    {
+        $this->inventory = $this
+            ->getMockBuilder(Inventory::class)
+            ->getMock()
+        ;
+        $this->host = $this
+            ->getMockBuilder(Host::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->ssh = $this
+            ->getMockBuilder(ClientInterface::class)
+            ->getMock()
+        ;
+
+        $this->command = new PingCommand;
+        #$this->command->setInventory($this->inventory);
+
+        $this->app = new Application;
+        $this->app->add($this->command);
+
+        $this->tester = new CommandTester($this->command);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage To perform this command I require an Inventory of Hosts
+     * @covers \Droid\Command\PingCommand::configure
+     * @covers \Droid\Command\PingCommand::initialize
+     */
+    public function testCommandWithoutInventoryWillThrowException()
+    {
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            'hostname' => 'some-host-name',
+        ));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage To perform this command I require an Inventory of Hosts
+     * @covers \Droid\Command\PingCommand::configure
+     * @covers \Droid\Command\PingCommand::initialize
+     */
+    public function testCommandWithoutHostsWillThrowException()
+    {
+        $this->command->setInventory($this->inventory);
+        $this
+            ->inventory
+            ->method('getHosts')
+            ->willReturn(array())
+        ;
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            'hostname' => 'some-host-name',
+        ));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @covers \Droid\Command\PingCommand::configure
+     * @covers \Droid\Command\PingCommand::execute
+     */
+    public function testCommandWithNameOfUnknownHostWillThrowException()
+    {
+        $this->command->setInventory($this->inventory);
+        $this
+            ->inventory
+            ->method('getHosts')
+            ->willReturn(array($this->host))
+        ;
+        $this
+            ->inventory
+            ->expects($this->once())
+            ->method('getHost')
+            ->with($this->equalTo('some-host-name'))
+            ->willThrowException(new RuntimeException)
+        ;
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            'hostname' => 'some-host-name',
+        ));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage I cannot ping the host named "some-host-name": there is no "keyfile" (SSH IdentityFile) configured with which to authenticate the "some-user-name" user
+     * @covers \Droid\Command\PingCommand::configure
+     * @covers \Droid\Command\PingCommand::execute
+     */
+    public function testCommandWithNameOfImproperlyConfiguredHostWillThrowException()
+    {
+        $this->command->setInventory($this->inventory);
+        $this
+            ->inventory
+            ->method('getHosts')
+            ->willReturn(array($this->host))
+        ;
+        $this
+            ->inventory
+            ->method('getHost')
+            ->willReturn($this->host)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getKeyFile')
+            ->willReturn(null)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('some-host-name')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getUsername')
+            ->willReturn('some-user-name')
+        ;
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            'hostname' => 'some-host-name',
+        ));
+    }
+
+    /**
+     * @covers \Droid\Command\PingCommand::execute
+     */
+    public function testCommandWithFailedPingWillOutputErrorMessage()
+    {
+        $this->command->setInventory($this->inventory);
+        $this
+            ->inventory
+            ->method('getHosts')
+            ->willReturn(array($this->host))
+        ;
+        $this
+            ->inventory
+            ->method('getHost')
+            ->willReturn($this->host)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getKeyFile')
+            ->willReturn('file')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getSshClient')
+            ->willReturn($this->ssh)
+        ;
+        $this
+            ->host
+            ->expects($this->atLeastOnce())
+            ->method('getName')
+            ->willReturn('host1')
+        ;
+        $this
+            ->ssh
+            ->expects($this->once())
+            ->method('exec')
+            ->with($this->equalTo(array('/bin/true')))
+        ;
+        $this
+            ->ssh
+            ->expects($this->exactly(2))
+            ->method('getExitCode')
+            ->willReturn(127)
+        ;
+        $this
+            ->ssh
+            ->expects($this->once())
+            ->method('getErrorOutput')
+            ->willReturn('some stderr output')
+        ;
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+        ));
+
+        $this->assertRegExp(
+            '/I attempt to Ping 1 host/',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/host1 Ping fail \(code 127\)/',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/some stderr output/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    /**
+     * @covers \Droid\Command\PingCommand::execute
+     */
+    public function testCommandWithSuccessfullPingWillOutputSuucessMessage()
+    {
+        $this->command->setInventory($this->inventory);
+        $this
+            ->inventory
+            ->method('getHosts')
+            ->willReturn(array($this->host))
+        ;
+        $this
+            ->inventory
+            ->method('getHost')
+            ->willReturn($this->host)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getKeyFile')
+            ->willReturn('file')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getSshClient')
+            ->willReturn($this->ssh)
+        ;
+        $this
+            ->host
+            ->expects($this->atLeastOnce())
+            ->method('getName')
+            ->willReturn('host1')
+        ;
+        $this
+            ->ssh
+            ->expects($this->once())
+            ->method('exec')
+            ->with($this->equalTo(array('/bin/true')))
+        ;
+        $this
+            ->ssh
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(0)
+        ;
+        $this
+            ->ssh
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('some stdout output')
+        ;
+        $this
+            ->ssh
+            ->expects($this->once())
+            ->method('getErrorOutput')
+            ->willReturn('some stderr output')
+        ;
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+        ));
+
+        $this->assertRegExp(
+            '/I attempt to Ping 1 host/',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/host1\s*Pong/',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/some stdout output/',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/some stderr output/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    /**
+     * @covers \Droid\Command\PingCommand::configure
+     * @covers \Droid\Command\PingCommand::execute
+     */
+    public function testCommandWithoutArgsWillPingAllSuitableHosts()
+    {
+        $this->command->setInventory($this->inventory);
+        $this
+            ->inventory
+            ->method('getHosts')
+            ->willReturn(array($this->host, $this->host, $this->host))
+        ;
+        $this
+            ->host
+            ->expects($this->exactly(3))
+            ->method('getKeyFile')
+            ->willReturnOnConsecutiveCalls('file', 'file', null)
+        ;
+        $this
+            ->host
+            ->expects($this->exactly(2))
+            ->method('getSshClient')
+            ->willReturn($this->ssh)
+        ;
+        $this
+            ->host
+            ->expects($this->exactly(4))
+            ->method('getName')
+            ->willReturnOnConsecutiveCalls('host1', 'host1', 'host2', 'host2')
+        ;
+        $this
+            ->ssh
+            ->expects($this->exactly(2))
+            ->method('exec')
+            ->with($this->equalTo(array('/bin/true')))
+        ;
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+        ));
+
+        $this->assertRegExp(
+            '/I attempt to Ping 2 hosts/',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/host1\s*Pong/',
+            $this->tester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/host2\s*Pong/',
+            $this->tester->getDisplay()
+        );
+    }
+}

--- a/test/Droid/Logger/LoggerFactoryTest.php
+++ b/test/Droid/Logger/LoggerFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Droid\Test\Logger;
+
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Droid\Logger\LoggerFactory;
+use Droid\Logger\ConsoleLogger;
+
+class LoggerFactoryTest extends PHPUnit_Framework_TestCase
+{
+    protected $output;
+
+    protected function setUp()
+    {
+        $this->output = $this
+            ->getMockBuilder(OutputInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @covers \Droid\Logger\LoggerFactory::makeLogger
+     */
+    public function testMakeLoggerWillReturnInstanceofConsoleLogger()
+    {
+        $fac = new LoggerFactory;
+
+        $this->assertInstanceof(
+            ConsoleLogger::class,
+            $fac->makeLogger($this->output),
+            'LoggerFactory produces instances of ConsoleLogger.'
+        );
+    }
+}

--- a/test/Droid/TaskRunner/PrepareCommandInputTest.php
+++ b/test/Droid/TaskRunner/PrepareCommandInputTest.php
@@ -2,13 +2,15 @@
 
 namespace Droid\Test\TaskRunner;
 
-use Droid\Model\Inventory\Remote\EnablerInterface;
+use Droid\Model\Inventory\Remote\Enabler;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use Droid\Application;
+use Droid\Logger\LoggerFactory;
 use Droid\TaskRunner;
 use Droid\Transform\Transformer;
 
@@ -19,6 +21,8 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
     private $app;
     private $command;
     private $enabler;
+    private $logger;
+    private $loggerFac;
     private $output;
     private $taskRunner;
     private $transformer;
@@ -28,7 +32,7 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
         $this->app = new Application($this->autoloader);
         $this->command = $this->getMockCommand();
         $this->enabler = $this
-            ->getMockBuilder(EnablerInterface::class)
+            ->getMockBuilder(Enabler::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -41,14 +45,28 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
+        $this->logger = $this
+            ->getMockBuilder(LoggerInterface::class)
+            ->getMock()
+        ;
+        $this->loggerFac = $this
+            ->getMockBuilder(LoggerFactory::class)
+            ->getMock()
+        ;
+        $this
+            ->loggerFac
+            ->method('makeLogger')
+            ->willReturn($this->logger)
+        ;
         $this->taskRunner = new TaskRunner(
             $this->app,
-            $this->transformer
+            $this->transformer,
+            $this->loggerFac
         );
         $this
             ->taskRunner
-            ->setOutput($this->output)
             ->setEnabler($this->enabler)
+            ->setOutput($this->output)
         ;
     }
 

--- a/test/Droid/TaskRunner/RunRemoteCommandTest.php
+++ b/test/Droid/TaskRunner/RunRemoteCommandTest.php
@@ -252,6 +252,30 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
         $this
             ->host
             ->expects($this->once())
+            ->method('getWorkingDirectory')
+            ->willReturn('/tmp')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getDroidCommandPrefix')
+            ->willReturn('droid')
+        ;
+        $this
+            ->command
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('do:something')
+        ;
+        $this
+            ->input
+            ->expects($this->once())
+            ->method('__toString')
+            ->willReturn('--now')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
             ->method('getSshClient')
             ->willReturn($this->sshClient)
         ;
@@ -259,7 +283,94 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
             ->sshClient
             ->expects($this->once())
             ->method('startExec')
-            ->with($this->isType('array'))
+            ->with(
+                array(
+                    'cd /tmp;',
+                    'droid',
+                    'do:something',
+                    '--now',
+                    '--ansi',
+                )
+            )
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(0)
+        ;
+
+        $this->taskRunner->runRemoteCommand(
+            $this->task,
+            $this->command,
+            array($this->host->getName() => $this->input),
+            array($this->host)
+        );
+    }
+
+    public function testRunRemoteCommandElevated()
+    {
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('enabled')
+            ->willReturn(false)
+        ;
+        $this
+            ->enabler
+            ->expects($this->once())
+            ->method('enable')
+            ->with($this->host)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getWorkingDirectory')
+            ->willReturn('/tmp')
+        ;
+        $this
+            ->task
+            ->expects($this->once())
+            ->method('getElevatePrivileges')
+            ->willReturn(true)
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getDroidCommandPrefix')
+            ->willReturn('droid')
+        ;
+        $this
+            ->command
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('do:something')
+        ;
+        $this
+            ->input
+            ->expects($this->once())
+            ->method('__toString')
+            ->willReturn('--now')
+        ;
+        $this
+            ->host
+            ->expects($this->once())
+            ->method('getSshClient')
+            ->willReturn($this->sshClient)
+        ;
+        $this
+            ->sshClient
+            ->expects($this->once())
+            ->method('startExec')
+            ->with(
+                array(
+                    'cd /tmp;',
+                    'sudo droid',
+                    'do:something',
+                    '--now',
+                    '--ansi',
+                )
+            )
         ;
         $this
             ->sshClient

--- a/test/Droid/TaskRunner/RunTaskListTest.php
+++ b/test/Droid/TaskRunner/RunTaskListTest.php
@@ -6,12 +6,14 @@ use RuntimeException;
 
 use Droid\Model\Inventory\Host;
 use Droid\Model\Inventory\Inventory;
-use Droid\Model\Inventory\Remote\EnablerInterface;
+use Droid\Model\Inventory\Remote\Enabler;
 use Droid\Model\Project\Target;
 use Droid\Model\Project\Task;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use Droid\Application;
+use Droid\Logger\LoggerFactory;
 use Droid\TaskRunner;
 use Droid\Test\AutoloaderAwareTestCase;
 use Droid\Transform\Transformer;
@@ -22,6 +24,8 @@ class RunTaskListTest extends AutoloaderAwareTestCase
     private $enabler;
     private $host;
     private $inventory;
+    private $logger;
+    private $loggerFac;
     private $output;
     private $target;
     private $task;
@@ -37,7 +41,7 @@ class RunTaskListTest extends AutoloaderAwareTestCase
             ->getMock()
         ;
         $this->enabler = $this
-            ->getMockBuilder(EnablerInterface::class)
+            ->getMockBuilder(Enabler::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -49,6 +53,19 @@ class RunTaskListTest extends AutoloaderAwareTestCase
         $this->inventory = $this
             ->getMockBuilder(Inventory::class)
             ->getMock()
+        ;
+        $this->logger = $this
+            ->getMockBuilder(LoggerInterface::class)
+            ->getMock()
+        ;
+        $this->loggerFac = $this
+            ->getMockBuilder(LoggerFactory::class)
+            ->getMock()
+        ;
+        $this
+            ->loggerFac
+            ->method('makeLogger')
+            ->willReturn($this->logger)
         ;
         $this->output = $this
             ->getMockBuilder(OutputInterface::class)
@@ -71,12 +88,12 @@ class RunTaskListTest extends AutoloaderAwareTestCase
         $this->taskRunner = $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer)
+                array($this->app, $this->transformer, $this->loggerFac)
             )
             ->setMethods(array('runTaskRemotely', 'runTaskLocally'))
             ->getMock()
-            ->setOutput($this->output)
             ->setEnabler($this->enabler)
+            ->setOutput($this->output)
         ;
     }
 

--- a/test/Droid/TaskRunner/RunTaskLocallyTest.php
+++ b/test/Droid/TaskRunner/RunTaskLocallyTest.php
@@ -4,13 +4,15 @@ namespace Droid\Test\TaskRunner;
 
 use Droid\Model\Inventory\Host;
 use Droid\Model\Inventory\Inventory;
-use Droid\Model\Inventory\Remote\EnablerInterface;
+use Droid\Model\Inventory\Remote\Enabler;
 use Droid\Model\Project\Task;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use Droid\Application;
+use Droid\Logger\LoggerFactory;
 use Droid\TaskRunner;
 use Droid\Test\AutoloaderAwareTestCase;
 use Droid\Transform\Transformer;
@@ -22,6 +24,8 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
     private $enabler;
     private $host;
     private $inventory;
+    private $logger;
+    private $loggerFac;
     private $output;
     private $task;
     private $taskRunner;
@@ -32,7 +36,7 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
         $this->app = $this->getPartialMockApplication();
         $this->command = $this->getMockCommand();
         $this->enabler = $this
-            ->getMockBuilder(EnablerInterface::class)
+            ->getMockBuilder(Enabler::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -44,6 +48,19 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
         $this->inventory = $this
             ->getMockBuilder(Inventory::class)
             ->getMock()
+        ;
+        $this->logger = $this
+            ->getMockBuilder(LoggerInterface::class)
+            ->getMock()
+        ;
+        $this->loggerFac = $this
+            ->getMockBuilder(LoggerFactory::class)
+            ->getMock()
+        ;
+        $this
+            ->loggerFac
+            ->method('makeLogger')
+            ->willReturn($this->logger)
         ;
         $this->output = $this
             ->getMockBuilder(OutputInterface::class)
@@ -87,7 +104,7 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
         return $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer)
+                array($this->app, $this->transformer, $this->loggerFac)
             )
             ->setMethods(
                 array(
@@ -98,8 +115,8 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
                 )
             )
             ->getMock()
-            ->setOutput($this->output)
             ->setEnabler($this->enabler)
+            ->setOutput($this->output)
         ;
     }
 

--- a/test/Droid/TaskRunner/RunTaskRemotelyTest.php
+++ b/test/Droid/TaskRunner/RunTaskRemotelyTest.php
@@ -4,13 +4,15 @@ namespace Droid\Test\TaskRunner;
 
 use Droid\Model\Inventory\Host;
 use Droid\Model\Inventory\Inventory;
-use Droid\Model\Inventory\Remote\EnablerInterface;
+use Droid\Model\Inventory\Remote\Enabler;
 use Droid\Model\Project\Task;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use Droid\Application;
+use Droid\Logger\LoggerFactory;
 use Droid\TaskRunner;
 use Droid\Test\AutoloaderAwareTestCase;
 use Droid\Transform\Transformer;
@@ -22,6 +24,8 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
     private $enabler;
     private $host;
     private $inventory;
+    private $logger;
+    private $loggerFac;
     private $output;
     private $task;
     private $taskRunner;
@@ -32,7 +36,7 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
         $this->app = $this->getPartialMockApplication();
         $this->command = $this->getMockCommand();
         $this->enabler = $this
-            ->getMockBuilder(EnablerInterface::class)
+            ->getMockBuilder(Enabler::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -44,6 +48,19 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
         $this->inventory = $this
             ->getMockBuilder(Inventory::class)
             ->getMock()
+        ;
+        $this->logger = $this
+            ->getMockBuilder(LoggerInterface::class)
+            ->getMock()
+        ;
+        $this->loggerFac = $this
+            ->getMockBuilder(LoggerFactory::class)
+            ->getMock()
+        ;
+        $this
+            ->loggerFac
+            ->method('makeLogger')
+            ->willReturn($this->logger)
         ;
         $this->output = $this
             ->getMockBuilder(OutputInterface::class)
@@ -81,7 +98,7 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
         return $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer)
+                array($this->app, $this->transformer, $this->loggerFac)
             )
             ->setMethods(
                 array(
@@ -92,8 +109,8 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
                 )
             )
             ->getMock()
-            ->setOutput($this->output)
             ->setEnabler($this->enabler)
+            ->setOutput($this->output)
         ;
     }
 

--- a/test/Droid/TaskRunner/SetOutputTest.php
+++ b/test/Droid/TaskRunner/SetOutputTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Droid\Test\TaskRunner;
+
+use Droid\Model\Inventory\Remote\Enabler;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Droid\Application;
+use Droid\Logger\LoggerFactory;
+use Droid\TaskRunner;
+use Droid\Test\AutoloaderAwareTestCase;
+use Droid\Transform\Transformer;
+
+class SetOutputTest extends AutoloaderAwareTestCase
+{
+    private $app;
+    private $enabler;
+    private $logger;
+    private $loggerFac;
+    private $output;
+    private $taskRunner;
+    private $transformer;
+
+    public function setUp()
+    {
+        $this->app = $this
+            ->getMockBuilder(Application::class)
+            ->setConstructorArgs(array($this->autoloader))
+            ->setMethods(array('hasInventory'))
+            ->getMock()
+        ;
+        $this->enabler = $this
+            ->getMockBuilder(Enabler::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->logger = $this
+            ->getMockBuilder(LoggerInterface::class)
+            ->getMock()
+        ;
+        $this->loggerFac = $this
+            ->getMockBuilder(LoggerFactory::class)
+            ->getMock()
+        ;
+        $this->output = $this
+            ->getMockBuilder(OutputInterface::class)
+            ->getMock()
+        ;
+        $this->transformer = $this
+            ->getMockBuilder(Transformer::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->taskRunner = new TaskRunner(
+            $this->app,
+            $this->transformer,
+            $this->loggerFac
+        );
+        $this
+            ->taskRunner
+            ->setEnabler($this->enabler)
+        ;
+    }
+
+    public function testSetOutputWillInjectLoggerIntoEnabler()
+    {
+        $this
+            ->loggerFac
+            ->expects($this->once())
+            ->method('makeLogger')
+            ->with($this->equalTo($this->output))
+            ->willReturn($this->logger)
+        ;
+        $this
+            ->enabler
+            ->expects($this->once())
+            ->method('setLogger')
+            ->with($this->logger)
+        ;
+
+        $this->taskRunner->setOutput($this->output);
+    }
+}


### PR DESCRIPTION
- Tasks may now use `sudo: true` to elevate the privileges of command execution.
- Application configures a WorkingDirectoryCheck with a working directory of /usr/local/droid. The existence and usability of this dir is checked as part of enabling droid on a remote host (Enabler).  Host.workingDirectory is set to this dir if so (otherwise, the working directory will be the default: /tmp).
- Enabler, its checks and synchronisers output progress information while enabling droid on a host. Basic progress info is augmented with an increase in verbosity.
- Add a ping command

Please release this and droid-model, after merge.
