### PR TITLE
Twig (& GeneratePlugin improvement)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/expression-language": "^3.1",
         "symfony/yaml": "~2.7",
         "ssh-client/ssh-client": "~0.1",
+        "twig/twig": "^1.27",
         "zordius/lightncandy": "~0.93"
     },
     "require-dev": {

--- a/generator/plugin/src/Command/DroidExampleCommand.php
+++ b/generator/plugin/src/Command/DroidExampleCommand.php
@@ -4,16 +4,16 @@ namespace Droid\Plugin\{{classname}}\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use RuntimeException;
 
 class {{classname}}ExampleCommand extends Command
 {
     public function configure()
     {
-        $this->setName('{{name}}:example')
+        $this
+            ->setName('{{name}}:example')
             ->setDescription('This is an example command')
             ->addArgument(
                 'message',
@@ -28,7 +28,7 @@ class {{classname}}ExampleCommand extends Command
             )
         ;
     }
-    
+
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeLn("{{classname}} Example: " . $input->getArgument('message') . " @ " . $input->getOption('color'));

--- a/generator/plugin/src/DroidPlugin.php
+++ b/generator/plugin/src/DroidPlugin.php
@@ -2,17 +2,19 @@
 
 namespace Droid\Plugin\{{classname}};
 
+use Droid\Plugin\{{classname}}\Command\{{classname}}ExampleCommand;
+
 class DroidPlugin
 {
     public function __construct($droid)
     {
         $this->droid = $droid;
     }
-    
+
     public function getCommands()
     {
         $commands = [];
-        $commands[] = new \Droid\Plugin\{{classname}}\Command\{{classname}}ExampleCommand();
+        $commands[] = new {{classname}}ExampleCommand();
         return $commands;
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Twig_Environment;
+use Twig_Loader_Array;
 
 use Droid\Command\TargetRunCommand;
 use Droid\Loader\YamlLoader;
@@ -28,6 +30,7 @@ use Droid\Transform\DataStreamTransformer;
 use Droid\Transform\FileTransformer;
 use Droid\Transform\InventoryTransformer;
 use Droid\Transform\Render\LightnCandyRenderer;
+use Droid\Transform\Render\TwigRenderer;
 use Droid\Transform\SubstitutionTransformer;
 use Droid\Transform\Transformer;
 
@@ -197,7 +200,8 @@ class Application extends ConsoleApplication
                 $this,
                 $this->transformer,
                 new LoggerFactory,
-                new ExpressionLanguage
+                new ExpressionLanguage,
+                $this->buildLegacyTransformer()
             );
             $enabler = $this->configureHostEnabler();
             if (! $enabler) {
@@ -297,6 +301,19 @@ class Application extends ConsoleApplication
         return $candidatePath;
     }
 
+    protected function buildLegacyTransformer()
+    {
+        return new Transformer(
+            new DataStreamTransformer,
+            new FileTransformer,
+            new InventoryTransformer(
+                $this->inventory,
+                PropertyAccess::createPropertyAccessor()
+            ),
+            new SubstitutionTransformer(new LightnCandyRenderer)
+        );
+    }
+
     protected function buildTransformer()
     {
         return new Transformer(
@@ -306,8 +323,21 @@ class Application extends ConsoleApplication
                 $this->inventory,
                 PropertyAccess::createPropertyAccessor()
             ),
-            new SubstitutionTransformer(
-                new LightnCandyRenderer
+            new SubstitutionTransformer($this->buildTemplateRenderer())
+        );
+    }
+
+    protected function buildTemplateRenderer()
+    {
+        return new TwigRenderer(
+            new Twig_Environment(
+                new Twig_Loader_Array(array()),
+                array(
+                    'charset' => 'utf-8',
+                    'cache' => false,
+                    'strict_variables' => true,
+                    'autoescape' => false,
+                )
             )
         );
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 use Droid\Command\TargetRunCommand;
 use Droid\Loader\YamlLoader;
@@ -195,7 +196,8 @@ class Application extends ConsoleApplication
             $runner = new TaskRunner(
                 $this,
                 $this->transformer,
-                new LoggerFactory
+                new LoggerFactory,
+                new ExpressionLanguage
             );
             $enabler = $this->configureHostEnabler();
             if (! $enabler) {

--- a/src/Command/GeneratePluginCommand.php
+++ b/src/Command/GeneratePluginCommand.php
@@ -11,9 +11,23 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use Droid\Generator;
+use Droid\Logger\LoggerFactory;
 
 class GeneratePluginCommand extends Command
 {
+    private $loggerFac;
+    private $pluginGen;
+
+    public function __construct(
+        Generator $pluginGenerator,
+        LoggerFactory $loggerFactory,
+        $name = null
+    ) {
+        $this->pluginGen = $pluginGenerator;
+        $this->loggerFac = $loggerFactory;
+        parent::__construct($name);
+    }
+
     public function configure()
     {
         $help = <<<'EOT'
@@ -69,7 +83,7 @@ EOT;
         $data['name'] = $name;
         $data['classname'] = ucfirst($name);
 
-        $generator = new Generator();
-        $generator->generate(__DIR__ . '/../../generator/plugin', $basePath, $data);
+        $this->pluginGen->setLogger($this->loggerFac->makeLogger($output));
+        $this->pluginGen->generate(__DIR__ . '/../../generator/plugin', $basePath, $data);
     }
 }

--- a/src/Command/GeneratePluginCommand.php
+++ b/src/Command/GeneratePluginCommand.php
@@ -2,34 +2,54 @@
 
 namespace Droid\Command;
 
+use RuntimeException;
+
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+
 use Droid\Generator;
-use RuntimeException;
 
 class GeneratePluginCommand extends Command
 {
     public function configure()
     {
+        $help = <<<'EOT'
+This command creates a skeleton project for a Droid Command plugin.
+
+A Command Plugin is a collection of one or more Console Commands.  The name
+given to the plugin is a namespace for the Commands. For example, the mysql
+plugin includes the commands:-
+
+    mysql:load
+    mysql:dump
+
+When the name argument is given, the plugin project is created in a directory of
+the same name.  The directory must exist.
+
+When the name argument is omitted, the plugin project is created in the current
+working directory and the name of the plugin becomes the directory name.
+EOT;
+
         $this->setName('generate:plugin')
-            ->setDescription('Generate a plugin project')
+            ->setDescription('Generate a project for the development of a Command Plugin.')
             ->addArgument(
                 'name',
                 InputArgument::OPTIONAL,
-                'Name of the plugin. For example: droid-hello'
+                'Name of the Plugin.'
             )
             ->addOption(
                 'force',
                 'f',
                 InputOption::VALUE_NONE,
-                'Force initialization, even if project appears to have been initialized before'
+                'Force generation when the plugin appears to already exist (.git/ exists).'
             )
+            ->setHelp($help)
         ;
     }
-    
+
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('name');
@@ -38,20 +58,18 @@ class GeneratePluginCommand extends Command
             $basePath = getcwd();
             $name = basename($basePath);
         }
+        if (!$input->getOption('force') && file_exists($basePath . '/.git')) {
+            throw new RuntimeException('Plugin appears to already exist (.git/ exists).');
+        }
+
         $name = str_replace('droid-', '', $name);
         $output->writeLn("Generating: <info>" . $name . "</info> in <comment>" . $basePath . '</comment>');
-        if (!$input->getOption('force')) {
-            if (file_exists($basePath . '/.git')) {
-                throw new RuntimeException("Project path already initialized");
-            }
-        }
-        $generator = new Generator();
+
         $data = [];
         $data['name'] = $name;
         $data['classname'] = ucfirst($name);
+
+        $generator = new Generator();
         $generator->generate(__DIR__ . '/../../generator/plugin', $basePath, $data);
-        
-        //$output->writeLn($input->getArgument('message'));
-        //return 0;
     }
 }

--- a/src/Command/GeneratePluginCommand.php
+++ b/src/Command/GeneratePluginCommand.php
@@ -81,7 +81,15 @@ EOT;
 
         $data = [];
         $data['name'] = $name;
-        $data['classname'] = ucfirst($name);
+        $data['classname'] = implode(
+            '',
+            array_map(
+                function ($x) {
+                    return ucfirst($x);
+                },
+                preg_split('/[_-]+/', $name, null, PREG_SPLIT_NO_EMPTY)
+            )
+        );
 
         $this->pluginGen->setLogger($this->loggerFac->makeLogger($output));
         $this->pluginGen->generate(__DIR__ . '/../../generator/plugin', $basePath, $data);

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -2,6 +2,9 @@
 
 namespace Droid;
 
+use Droid\Generator;
+use Droid\Logger\LoggerFactory;
+
 class DroidPlugin
 {
     public function __construct($droid)
@@ -15,7 +18,10 @@ class DroidPlugin
         $commands[] = new \Droid\Command\TargetRunCommand();
         $commands[] = new \Droid\Command\ConfigCommand();
         $commands[] = new \Droid\Command\DebugEchoCommand();
-        $commands[] = new \Droid\Command\GeneratePluginCommand();
+        $commands[] = new \Droid\Command\GeneratePluginCommand(
+            new Generator,
+            new LoggerFactory
+        );
         $commands[] = new \Droid\Command\InventoryCommand();
         $commands[] = new \Droid\Command\ModuleInstallCommand();
         $commands[] = new \Droid\Command\PingCommand;

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -8,7 +8,7 @@ class DroidPlugin
     {
         $this->droid = $droid;
     }
-    
+
     public function getCommands()
     {
         $commands = [];

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -6,6 +6,8 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
 
+use Psr\Log\LoggerInterface;
+
 class Generator
 {
     public function generate($src, $dest, $data = [])
@@ -37,7 +39,7 @@ class Generator
 
             $content = $this->processContent(file_get_contents($file), $data);
 
-            echo "FILE: " . $relDir . $filename . "\n";
+            $this->logInfo(sprintf('Writing "%s"', $relDir . $filename));
 
             file_put_contents($writePath, $content);
         }
@@ -49,5 +51,18 @@ class Generator
             $content = str_replace('{{'  . $key . '}}', $value, $content);
         }
         return $content;
+    }
+
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    private function logInfo($message)
+    {
+        if (! $this->logger) {
+            return;
+        }
+        $this->logger->info($message);
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -39,6 +39,17 @@ class Generator
 
             $content = $this->processContent(file_get_contents($file), $data);
 
+            // do any rename operations
+            //
+            // rename Droid*Command.php to match the class name
+            $m = [];
+            if (array_key_exists('classname', $data)
+                && preg_match('/Droid(\w*)Command.php/', $filename, $m)
+            ) {
+                $filename = sprintf('%s%sCommand.php', $data['classname'], $m[1]);
+                $writePath = $dest . DIRECTORY_SEPARATOR . $relDir . $filename;
+            }
+
             $this->logInfo(sprintf('Writing "%s"', $relDir . $filename));
 
             file_put_contents($writePath, $content);

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -92,7 +92,7 @@ class ConsoleLogger extends AbstractLogger
             } else {
                 $output->writeln(
                     sprintf(
-                        '<%1$s><wu-tang>Bring da ruckus</> %2$s</%1$s>',
+                        '<%1$s>%2$s</%1$s>',
                         $this->formatLevelMap[$level],
                         $this->interpolate($message, $context)
                     )

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -33,16 +33,12 @@ class TaskRunner
         Application $app,
         Transformer $transformer,
         LoggerFactory $loggerFactory,
-        ExpressionLanguage $expr = null
+        ExpressionLanguage $expr
     ) {
         $this->app = $app;
         $this->loggerFac = $loggerFactory;
         $this->transformer = $transformer;
-        if (! $expr) {
-            $this->expr = new ExpressionLanguage;
-        } else {
-            $this->expr = $expr;
-        }
+        $this->expr = $expr;
     }
 
     public function setEnabler(EnablerInterface $enabler)

--- a/src/Transform/Render/TwigRenderer.php
+++ b/src/Transform/Render/TwigRenderer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Droid\Transform\Render;
+
+use Twig_Environment;
+use Twig_Error;
+
+class TwigRenderer implements RendererInterface
+{
+    protected $twig;
+
+    public function __construct(Twig_Environment $twig)
+    {
+        $this->twig = $twig;
+    }
+
+    /**
+     * Add templates, as a map of name to template, to the template loader.
+     *
+     * @param array $templates
+     */
+    public function addTemplates($templates)
+    {
+        foreach ($templates as $name => $template) {
+            $this->twig->getLoader()->setTemplate($name, $template);
+        }
+    }
+
+    public function render($value, $context = array())
+    {
+        $result = null;
+
+        try {
+            $result = $this->twig->render($value, $context);
+        } catch (Twig_Error $e) {
+            throw new RendererException(
+                sprintf('Failed to render the template named "%s"', $value),
+                null,
+                $e
+            );
+        }
+
+        return $result;
+    }
+}

--- a/src/Transform/SubstitutionTransformer.php
+++ b/src/Transform/SubstitutionTransformer.php
@@ -16,6 +16,16 @@ class SubstitutionTransformer implements TransformerInterface
         $this->renderer = $renderer;
     }
 
+    /**
+     * Add templates, as a map of name to template, to the template renderer.
+     *
+     * @param array $templates
+     */
+    public function addTemplates($templates)
+    {
+        $this->renderer->addTemplates($templates);
+    }
+
     public function transform($value, $context = array())
     {
         if (! is_string($value)) {

--- a/src/Transform/Transformer.php
+++ b/src/Transform/Transformer.php
@@ -119,4 +119,17 @@ class Transformer
 
         return $result;
     }
+
+    /**
+     * Add templates to the substitution transformer.
+     *
+     * Each entry in the supplied array of templates should be the string
+     * template content, keyed by the name used to look up the template.
+     *
+     * @param array $templates
+     */
+    public function addTemplates($templates)
+    {
+        $this->substitutionTransformer->addTemplates($templates);
+    }
 }

--- a/test/Droid/TaskRunner/PrepareCommandInputTest.php
+++ b/test/Droid/TaskRunner/PrepareCommandInputTest.php
@@ -68,7 +68,8 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
             $this->app,
             $this->transformer,
             $this->loggerFac,
-            $this->expr
+            $this->expr,
+            $this->transformer
         );
         $this
             ->taskRunner
@@ -110,7 +111,7 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
         ;
         $this
             ->taskRunner
-            ->prepareCommandInput(
+            ->legacyPrepareCommandInput(
                 $this->command,
                 array('what' => $argumentValue),
                 $variables
@@ -130,7 +131,7 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
         ;
         $this
             ->taskRunner
-            ->prepareCommandInput(
+            ->legacyPrepareCommandInput(
                 $this->command,
                 array('what' => $argumentValue),
                 $variables
@@ -177,7 +178,7 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
 
         $this
             ->taskRunner
-            ->prepareCommandInput(
+            ->legacyPrepareCommandInput(
                 $this->command,
                 array('what' => $inputToMethod),
                 $variables
@@ -233,7 +234,7 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
 
         $this
             ->taskRunner
-            ->prepareCommandInput(
+            ->legacyPrepareCommandInput(
                 $this->command,
                 array('what' => $inputToMethod),
                 $variables

--- a/test/Droid/TaskRunner/PrepareCommandInputTest.php
+++ b/test/Droid/TaskRunner/PrepareCommandInputTest.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 use Droid\Application;
 use Droid\Logger\LoggerFactory;
@@ -21,6 +22,7 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
     private $app;
     private $command;
     private $enabler;
+    private $expr;
     private $logger;
     private $loggerFac;
     private $output;
@@ -53,6 +55,10 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
             ->getMockBuilder(LoggerFactory::class)
             ->getMock()
         ;
+        $this->expr = $this
+            ->getMockBuilder(ExpressionLanguage::class)
+            ->getMock()
+        ;
         $this
             ->loggerFac
             ->method('makeLogger')
@@ -61,7 +67,8 @@ class PrepareCommandInputTest extends AutoloaderAwareTestCase
         $this->taskRunner = new TaskRunner(
             $this->app,
             $this->transformer,
-            $this->loggerFac
+            $this->loggerFac,
+            $this->expr
         );
         $this
             ->taskRunner

--- a/test/Droid/TaskRunner/RunRemoteCommandTest.php
+++ b/test/Droid/TaskRunner/RunRemoteCommandTest.php
@@ -12,6 +12,7 @@ use SSHClient\Client\ClientInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 use Droid\Application;
 use Droid\Logger\LoggerFactory;
@@ -24,6 +25,7 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
     private $app;
     private $synchroniser;
     private $enabler;
+    private $expr;
     private $logger;
     private $loggerFac;
     private $output;
@@ -57,6 +59,10 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
         ;
         $this->loggerFac = $this
             ->getMockBuilder(LoggerFactory::class)
+            ->getMock()
+        ;
+        $this->expr = $this
+            ->getMockBuilder(ExpressionLanguage::class)
             ->getMock()
         ;
         $this
@@ -97,7 +103,8 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
         $this->taskRunner = new TaskRunner(
             $this->app,
             $this->transformer,
-            $this->loggerFac
+            $this->loggerFac,
+            $this->expr
         );
         $this
             ->taskRunner

--- a/test/Droid/TaskRunner/RunRemoteCommandTest.php
+++ b/test/Droid/TaskRunner/RunRemoteCommandTest.php
@@ -104,7 +104,8 @@ class RunRemoteCommandTest extends AutoloaderAwareTestCase
             $this->app,
             $this->transformer,
             $this->loggerFac,
-            $this->expr
+            $this->expr,
+            $this->transformer
         );
         $this
             ->taskRunner

--- a/test/Droid/TaskRunner/RunTaskListTest.php
+++ b/test/Droid/TaskRunner/RunTaskListTest.php
@@ -94,7 +94,7 @@ class RunTaskListTest extends AutoloaderAwareTestCase
         $this->taskRunner = $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer, $this->loggerFac, $this->expr)
+                array($this->app, $this->transformer, $this->loggerFac, $this->expr, $this->transformer)
             )
             ->setMethods(array('runTaskRemotely', 'runTaskLocally'))
             ->getMock()

--- a/test/Droid/TaskRunner/RunTaskListTest.php
+++ b/test/Droid/TaskRunner/RunTaskListTest.php
@@ -11,6 +11,7 @@ use Droid\Model\Project\Target;
 use Droid\Model\Project\Task;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 use Droid\Application;
 use Droid\Logger\LoggerFactory;
@@ -22,6 +23,7 @@ class RunTaskListTest extends AutoloaderAwareTestCase
 {
     private $app;
     private $enabler;
+    private $expr;
     private $host;
     private $inventory;
     private $logger;
@@ -62,6 +64,10 @@ class RunTaskListTest extends AutoloaderAwareTestCase
             ->getMockBuilder(LoggerFactory::class)
             ->getMock()
         ;
+        $this->expr = $this
+            ->getMockBuilder(ExpressionLanguage::class)
+            ->getMock()
+        ;
         $this
             ->loggerFac
             ->method('makeLogger')
@@ -88,7 +94,7 @@ class RunTaskListTest extends AutoloaderAwareTestCase
         $this->taskRunner = $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer, $this->loggerFac)
+                array($this->app, $this->transformer, $this->loggerFac, $this->expr)
             )
             ->setMethods(array('runTaskRemotely', 'runTaskLocally'))
             ->getMock()

--- a/test/Droid/TaskRunner/RunTaskLocallyTest.php
+++ b/test/Droid/TaskRunner/RunTaskLocallyTest.php
@@ -110,7 +110,7 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
         return $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer, $this->loggerFac, $this->expr)
+                array($this->app, $this->transformer, $this->loggerFac, $this->expr, $this->transformer)
             )
             ->setMethods(
                 array(

--- a/test/Droid/TaskRunner/RunTaskLocallyTest.php
+++ b/test/Droid/TaskRunner/RunTaskLocallyTest.php
@@ -10,6 +10,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 use Droid\Application;
 use Droid\Logger\LoggerFactory;
@@ -22,6 +23,7 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
     private $app;
     private $command;
     private $enabler;
+    private $expr;
     private $host;
     private $inventory;
     private $logger;
@@ -55,6 +57,10 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
         ;
         $this->loggerFac = $this
             ->getMockBuilder(LoggerFactory::class)
+            ->getMock()
+        ;
+        $this->expr = $this
+            ->getMockBuilder(ExpressionLanguage::class)
             ->getMock()
         ;
         $this
@@ -104,7 +110,7 @@ class RunTaskLocallyTest extends AutoloaderAwareTestCase
         return $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer, $this->loggerFac)
+                array($this->app, $this->transformer, $this->loggerFac, $this->expr)
             )
             ->setMethods(
                 array(

--- a/test/Droid/TaskRunner/RunTaskRemotelyTest.php
+++ b/test/Droid/TaskRunner/RunTaskRemotelyTest.php
@@ -10,6 +10,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 use Droid\Application;
 use Droid\Logger\LoggerFactory;
@@ -22,6 +23,7 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
     private $app;
     private $command;
     private $enabler;
+    private $expr;
     private $host;
     private $inventory;
     private $logger;
@@ -57,6 +59,7 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
             ->getMockBuilder(LoggerFactory::class)
             ->getMock()
         ;
+        $this->expr = new ExpressionLanguage;;
         $this
             ->loggerFac
             ->method('makeLogger')
@@ -98,7 +101,7 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
         return $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer, $this->loggerFac)
+                array($this->app, $this->transformer, $this->loggerFac, $this->expr)
             )
             ->setMethods(
                 array(

--- a/test/Droid/TaskRunner/RunTaskRemotelyTest.php
+++ b/test/Droid/TaskRunner/RunTaskRemotelyTest.php
@@ -17,6 +17,7 @@ use Droid\Logger\LoggerFactory;
 use Droid\TaskRunner;
 use Droid\Test\AutoloaderAwareTestCase;
 use Droid\Transform\Transformer;
+use Droid\Transform\SubstitutionTransformer;
 
 class RunTaskRemotelyTest extends AutoloaderAwareTestCase
 {
@@ -73,10 +74,20 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
             ->getMockBuilder(Task::class)
             ->getMock()
         ;
+        $this->substitutionTransformer = $this
+            ->getMockBuilder(SubstitutionTransformer::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
         $this->transformer = $this
             ->getMockBuilder(Transformer::class)
             ->disableOriginalConstructor()
             ->getMock()
+        ;
+        $this
+            ->transformer
+            ->method('getSubstitutionTransformer')
+            ->willReturn($this->substitutionTransformer)
         ;
         $this->taskRunner = $this->getPartialMockTaskRunner();
     }
@@ -101,7 +112,7 @@ class RunTaskRemotelyTest extends AutoloaderAwareTestCase
         return $this
             ->getMockBuilder(TaskRunner::class)
             ->setConstructorArgs(
-                array($this->app, $this->transformer, $this->loggerFac, $this->expr)
+                array($this->app, $this->transformer, $this->loggerFac, $this->expr, $this->transformer)
             )
             ->setMethods(
                 array(

--- a/test/Droid/TaskRunner/SetOutputTest.php
+++ b/test/Droid/TaskRunner/SetOutputTest.php
@@ -62,7 +62,8 @@ class SetOutputTest extends AutoloaderAwareTestCase
             $this->app,
             $this->transformer,
             $this->loggerFac,
-            $this->expr
+            $this->expr,
+            $this->transformer
         );
         $this
             ->taskRunner

--- a/test/Droid/TaskRunner/SetOutputTest.php
+++ b/test/Droid/TaskRunner/SetOutputTest.php
@@ -5,6 +5,7 @@ namespace Droid\Test\TaskRunner;
 use Droid\Model\Inventory\Remote\Enabler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 use Droid\Application;
 use Droid\Logger\LoggerFactory;
@@ -16,6 +17,7 @@ class SetOutputTest extends AutoloaderAwareTestCase
 {
     private $app;
     private $enabler;
+    private $expr;
     private $logger;
     private $loggerFac;
     private $output;
@@ -43,6 +45,10 @@ class SetOutputTest extends AutoloaderAwareTestCase
             ->getMockBuilder(LoggerFactory::class)
             ->getMock()
         ;
+        $this->expr = $this
+            ->getMockBuilder(ExpressionLanguage::class)
+            ->getMock()
+        ;
         $this->output = $this
             ->getMockBuilder(OutputInterface::class)
             ->getMock()
@@ -55,7 +61,8 @@ class SetOutputTest extends AutoloaderAwareTestCase
         $this->taskRunner = new TaskRunner(
             $this->app,
             $this->transformer,
-            $this->loggerFac
+            $this->loggerFac,
+            $this->expr
         );
         $this
             ->taskRunner


### PR DESCRIPTION
Use Twig in place of Lightncandy for command argument placeholder substitution and file template
rendering.

This changes breaks backward compatibility.  Projects wishing to continue using the Lightncandy syntax should include a variable `use_legacy_templating` at Project, Target or Module level.

There is a simplification of the magic characters used in Task.arguments (the old behaviour is maintained with `use_legacy_templating`):-

- the `@` character means: treat this arg as a file path and transform it into the content of the file
- the `!` character is gone; args beginning with `@` and ending in ".twig" or ".template" are automatically treated as file templates and fed to Twig